### PR TITLE
perf: ⚡️ challenge improving `LazyColumn` performance of `TaskList`

### DIFF
--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/Task.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/Task.kt
@@ -54,6 +54,7 @@ data class Task(
 
 // 子課題
 data class SubTask(
+    var id: Int,
     var title: String = "",
     var status: SubTaskStatus = SubTaskStatus.INCOMPLETE
 )

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/Task.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/Task.kt
@@ -65,84 +65,46 @@ enum class SubTaskStatus {
     COMPLETED,  // 完了
 }
 
-fun makeDummyTasks(): List<Task> {
-    return listOf(
+// ダミーの課題リスト: デバッグ用
+fun makeDummyTasks(numberOfTask: Int = 20): List<Task> {
+    return (0..<numberOfTask).map {
         Task(
-            id = 0,
-            title = "課題1",
-            color = Color(0xfff8dc6c),
-            subTasks = listOf(
-                SubTask(
-                    title = "課題1の子課題1",
-                    status = SubTaskStatus.INCOMPLETE
-                ),
-                SubTask(
-                    title = "課題1の子課題2",
-                    status = SubTaskStatus.INCOMPLETE
-                ),
-                SubTask(
-                    title = "課題1の子課題3",
-                    status = SubTaskStatus.COMPLETED
-                ),
-            ),
-            deadline = Date()
-        ),
-        Task(
-            id = 1,
-            title = "課題2",
-            color = Color(0xfff86e6c),
-            subTasks = listOf(
-                SubTask(
-                    title = "課題2の子課題1",
-                    status = SubTaskStatus.INCOMPLETE
-                ),
-                SubTask(
-                    title = "課題2の子課題2",
-                    status = SubTaskStatus.INCOMPLETE
-                ),
-                SubTask(
-                    title = "課題2の子課題3",
-                    status = SubTaskStatus.COMPLETED
-                ),
-                SubTask(
-                    title = "課題2の子課題4",
-                    status = SubTaskStatus.COMPLETED
-                ),
-            ),
-            deadline = Date()
-        ),
-        Task(
-            id = 2,
-            title = "課題3",
-            color = Color(0xff6cbef8),
-            subTasks = listOf(
-                SubTask(
-                    title = "課題3の子課題1",
-                    status = SubTaskStatus.INCOMPLETE
-                ),
-                SubTask(
-                    title = "課題3の子課題2",
-                    status = SubTaskStatus.COMPLETED
-                ),
-                SubTask(
-                    title = "課題3の子課題3",
-                    status = SubTaskStatus.COMPLETED
-                ),
-                SubTask(
-                    title = "課題3の子課題4",
-                    status = SubTaskStatus.COMPLETED
-                ),
-            ),
+            id = it,
+            title = "課題${it + 1}",
+            color = when (it % 3) {
+                0 -> Color(0xfff8dc6c)
+                1 -> Color(0xfff86e6c)
+                else -> Color(0xff6cbef8)
+            },
+            subTasks = makeDummySubTasks(it),
             deadline = Date()
         )
-    )
+    }
 }
 
-// ダミーの小課題リスト: デバッグ用
-fun makeDummySubTasks(): List<SubTask> {
-    return (0..<5).map {
+// ダミーの子課題リスト: デバッグ用
+fun makeDummySubTasks(taskId: Int = 0): List<SubTask> {
+    return (0..<7).map {
         SubTask(
-            title = "サブタスク$it",
-            status = if (it % 2 == 1) SubTaskStatus.COMPLETED else SubTaskStatus.INCOMPLETE)
+            id = it,
+            title = "課題${taskId + 1}の子課題$it",
+            status = when (taskId % 3) {
+                0 -> when (it) {
+                    1 -> SubTaskStatus.COMPLETED
+                    2 -> SubTaskStatus.ACTIVE
+                    else -> SubTaskStatus.INCOMPLETE
+                }
+                1 -> when (it) {
+                    in 0..2 -> SubTaskStatus.COMPLETED
+                    3 -> SubTaskStatus.ACTIVE
+                    else -> SubTaskStatus.INCOMPLETE
+                }
+                else -> when (it) {
+                    in 0..4 -> SubTaskStatus.COMPLETED
+                    5 -> SubTaskStatus.ACTIVE
+                    else -> SubTaskStatus.INCOMPLETE
+                }
+            }
+        )
     }
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskList.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskList.kt
@@ -27,7 +27,10 @@ fun TaskList(tasks: List<Task>, onClickItem: (id: Int) -> Unit) {
             .padding(all = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        items(tasks) { task ->
+        items(
+            tasks,
+            key = { task -> task.id }
+        ) { task ->
             TaskListItem(task = task, onClick = onClickItem)
         }
 

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
@@ -50,8 +50,10 @@ fun TaskListItem(task: Task, onClick: (id: Int) -> Unit) {
                 elevation = 6.dp,
                 shape = RoundedCornerShape(8.dp)
             )
-            .background(task.color.copy(alpha = 0.3f).compositeOver(Color.White))
-
+            .background(
+                task.color.copy(alpha = 0.3f)
+                    .compositeOver(Color.White)
+            )
         ,
         contentAlignment = Alignment.Center,
     ) {

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
@@ -29,8 +29,7 @@ import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.dashimaki_dofu.mytaskmanagement.R
 import com.dashimaki_dofu.mytaskmanagement.model.Task
-import com.dashimaki_dofu.mytaskmanagement.model.makeDummySubTasks
-import java.util.Date
+import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTasks
 
 
 /**
@@ -121,13 +120,7 @@ fun TaskListItem(task: Task, onClick: (id: Int) -> Unit) {
 @Composable
 fun TaskListItemPreview() {
     TaskListItem(
-        task = Task(
-            id = 0,
-            title = "世界観",
-            color = colorResource(id = R.color.taskColor1),
-            subTasks = makeDummySubTasks(),
-            deadline = Date()
-        ),
+        task = makeDummyTasks().first(),
         onClick = { }
     )
 }


### PR DESCRIPTION
## Overview
- 課題一覧の表示パフォーマンスの改善チャレンジ

## Implement Overview
- `SubTask` に `id` 追加
- `makeDummyTasks()` と `makeDummySubTasks()` をシステマティックに生成するように修正
- インデント調整
- `TaskList` の `LazyColumn` の `key` に `task.id` を指定
  - 特に改善は感じられないが、ベストプラクティスに近いので設定しておく

## Screen Shots
なし

## Related Issues
なし
