### PR TITLE
feat: 🎸 introduce `Room` & entitied models

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("kotlin-kapt")
 }
 
 android {
@@ -51,6 +52,7 @@ android {
 
 dependencies {
     val navVersion = "2.7.7"
+    val roomVersion = "2.6.1"
 
     implementation("androidx.core:core-ktx:1.10.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
@@ -63,6 +65,10 @@ dependencies {
     implementation("androidx.core:core-splashscreen:1.0.1")
     implementation("androidx.constraintlayout:constraintlayout-compose:1.0.0-alpha08")
     implementation("androidx.navigation:navigation-compose:${navVersion}")
+    implementation("androidx.room:room-runtime:${roomVersion}")
+    implementation("androidx.room:room-ktx:${roomVersion}")
+    annotationProcessor("androidx.room:room-compiler:${roomVersion}")
+    kapt("androidx.room:room-compiler:${roomVersion}")  // KSPに置き換えたいが、エラーが解決できないため一旦kaptで
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
           xmlns:tools="http://schemas.android.com/tools">
 
     <application
+            android:name=".RoomApplication"
             android:allowBackup="true"
             android:dataExtractionRules="@xml/data_extraction_rules"
             android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/RoomApplication.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/RoomApplication.kt
@@ -1,0 +1,30 @@
+package com.dashimaki_dofu.mytaskmanagement
+
+import android.app.Application
+import androidx.room.Room
+import com.dashimaki_dofu.mytaskmanagement.database.TaskDatabase
+
+
+/**
+ * RoomApplication
+ *
+ * Created by Yoshiyasu on 2024/02/10
+ */
+
+class RoomApplication: Application() {
+    companion object {
+        lateinit var database: TaskDatabase
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+
+        database = Room
+            .databaseBuilder(
+                context = applicationContext,
+                klass = TaskDatabase::class.java,
+                TaskDatabase.DATABASE_NAME
+            )
+            .build()
+    }
+}

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/database/TaskDao.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/database/TaskDao.kt
@@ -1,0 +1,44 @@
+package com.dashimaki_dofu.mytaskmanagement.database
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import com.dashimaki_dofu.mytaskmanagement.model.SubTask
+import com.dashimaki_dofu.mytaskmanagement.model.Task
+import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
+
+
+/**
+ * TaskDao
+ *
+ * Created by Yoshiyasu on 2024/02/10
+ */
+
+@Dao
+interface TaskDao {
+    @Transaction
+    @Query("select * from tasks")
+    suspend fun getAllTaskAndSubTasks(): List<TaskAndSubTasks>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTask(task: Task)
+
+    @Update
+    suspend fun updateTask(task: Task)
+
+    @Delete
+    suspend fun deleteTask(task: Task)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSubTask(subTask: SubTask)
+
+    @Update
+    suspend fun updateSubTask(subTask: SubTask)
+
+    @Delete
+    suspend fun deleteSubTask(subTask: SubTask)
+}

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/database/TaskDatabase.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/database/TaskDatabase.kt
@@ -1,0 +1,30 @@
+package com.dashimaki_dofu.mytaskmanagement.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.dashimaki_dofu.mytaskmanagement.database.typeConverter.DateConverter
+import com.dashimaki_dofu.mytaskmanagement.model.SubTask
+import com.dashimaki_dofu.mytaskmanagement.model.Task
+
+
+/**
+ * TaskDatabase
+ *
+ * Created by Yoshiyasu on 2024/02/10
+ */
+
+const val roomSchemaVersion = 1
+
+@Database(
+    entities = [Task::class, SubTask::class],
+    version = roomSchemaVersion,
+    exportSchema = false
+)
+@TypeConverters(DateConverter::class)
+abstract class TaskDatabase : RoomDatabase() {
+    companion object {
+        const val DATABASE_NAME = "tasks"
+    }
+    abstract fun taskDao(): TaskDao
+}

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/database/typeConverter/DateConverter.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/database/typeConverter/DateConverter.kt
@@ -1,0 +1,23 @@
+package com.dashimaki_dofu.mytaskmanagement.database.typeConverter
+
+import androidx.room.TypeConverter
+import java.util.Date
+
+
+/**
+ * DateConverter
+ *
+ * Created by Yoshiyasu on 2024/02/10
+ */
+
+class DateConverter {
+    @TypeConverter
+    fun fromTimestamp(value: Long?): Date? {
+        return value?.let { Date(it) }
+    }
+
+    @TypeConverter
+    fun toTimestamp(date: Date?): Long? {
+        return date?.time
+    }
+}

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/SubTask.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/SubTask.kt
@@ -1,0 +1,76 @@
+package com.dashimaki_dofu.mytaskmanagement.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+import com.dashimaki_dofu.mytaskmanagement.R
+
+
+/**
+ * SubTask
+ *
+ * Created by Yoshiyasu on 2024/02/11
+ */
+
+// 子課題
+@Entity(
+    tableName = "subTasks",
+    foreignKeys = [
+        ForeignKey(
+            entity = Task::class,
+            parentColumns = arrayOf("id"),
+            childColumns = arrayOf("taskId"),
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+data class SubTask(
+    @PrimaryKey(autoGenerate = true) var id: Int = -1,
+    @ColumnInfo(index = true) var taskId: Int = -1,
+    var title: String = "",
+    var status: SubTaskStatus = SubTaskStatus.INCOMPLETE
+) {
+    val stampResourceId: Int?
+        get() {
+            return when (status) {
+                SubTaskStatus.INCOMPLETE -> R.drawable.mark_incomplete_checked
+                SubTaskStatus.COMPLETED -> R.drawable.mark_sumi_checked
+                else -> null
+            }
+        }
+}
+
+enum class SubTaskStatus {
+    INCOMPLETE, // 未着手
+    ACTIVE,     // 着手中
+    COMPLETED,  // 完了
+}
+
+// ダミーの子課題リスト: デバッグ用
+fun makeDummySubTasks(taskId: Int = 0): List<SubTask> {
+    return (0..<10).map {
+        SubTask(
+            id = it,
+            taskId = taskId,
+            title = "課題${taskId + 1}の子課題${it + 1}",
+            status = when (taskId % 3) {
+                0 -> when (it) {
+                    in 0..1 -> SubTaskStatus.COMPLETED
+                    2 -> SubTaskStatus.ACTIVE
+                    else -> SubTaskStatus.INCOMPLETE
+                }
+                1 -> when (it) {
+                    in 0..2 -> SubTaskStatus.COMPLETED
+                    3 -> SubTaskStatus.ACTIVE
+                    else -> SubTaskStatus.INCOMPLETE
+                }
+                else -> when (it) {
+                    in 0..4 -> SubTaskStatus.COMPLETED
+                    5 -> SubTaskStatus.ACTIVE
+                    else -> SubTaskStatus.INCOMPLETE
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/Task.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/Task.kt
@@ -7,16 +7,17 @@ import androidx.core.graphics.blue
 import androidx.core.graphics.green
 import androidx.core.graphics.red
 import androidx.core.graphics.toColor
-import com.dashimaki_dofu.mytaskmanagement.R
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 import java.text.SimpleDateFormat
 import java.util.Date
 
 // 課題
+@Entity(tableName = "tasks")
 data class Task(
-    var id: Int,
-    var title: String,
-    var color: Color,
-    var subTasks: List<SubTask> = emptyList(),
+    @PrimaryKey(autoGenerate = true) var id: Int = -1,
+    var title: String = "",
+    var colorValue: Long = 0,
     var deadline: Date? = null
 ) {
     // 締切表示: "M/d"形式
@@ -27,6 +28,11 @@ data class Task(
                 return formatter.format(it)
             }
             return "-"
+        }
+
+    val color: Color
+        get() {
+            return Color(colorValue)
         }
 
     // 課題リスト上タイトルのフォントカラー
@@ -44,77 +50,22 @@ data class Task(
             hsl[2] -= 0.3f
             return Color(ColorUtils.HSLToColor(hsl).toColor().toArgb())
         }
-
-    // 課題の進捗率: 完了した課題の割合
-    val progressRate: Float
-        get() {
-            if (subTasks.isEmpty()) return 0f
-            return subTasks.count { it.status == SubTaskStatus.COMPLETED } / subTasks.count().toFloat()
-        }
-}
-
-// 子課題
-data class SubTask(
-    var id: Int,
-    var title: String = "",
-    var status: SubTaskStatus = SubTaskStatus.INCOMPLETE
-) {
-    val stampResourceId: Int?
-        get() {
-            return when (status) {
-                SubTaskStatus.INCOMPLETE -> R.drawable.mark_incomplete_checked
-                SubTaskStatus.COMPLETED -> R.drawable.mark_sumi_checked
-                else -> null
-            }
-        }
-}
-
-enum class SubTaskStatus {
-    INCOMPLETE, // 未着手
-    ACTIVE,     // 着手中
-    COMPLETED,  // 完了
 }
 
 // ダミーの課題リスト: デバッグ用
 fun makeDummyTasks(numberOfTask: Int = 20): List<Task> {
-    return (0..<numberOfTask).map {
-        Task(
-            id = it,
-            title = "課題${it + 1}",
-            color = when (it % 3) {
-                0 -> Color(0xfff8dc6c)
-                1 -> Color(0xfff86e6c)
-                else -> Color(0xff6cbef8)
-            },
-            subTasks = makeDummySubTasks(it),
-            deadline = Date()
-        )
-    }
+    return (0..<numberOfTask).map { makeDummyTask(it) }
 }
 
-// ダミーの子課題リスト: デバッグ用
-fun makeDummySubTasks(taskId: Int = 0): List<SubTask> {
-    return (0..<10).map {
-        SubTask(
-            id = it,
-            title = "課題${taskId + 1}の子課題${it + 1}",
-            status = when (taskId % 3) {
-                0 -> when (it) {
-                    in 0..1 -> SubTaskStatus.COMPLETED
-                    2 -> SubTaskStatus.ACTIVE
-                    else -> SubTaskStatus.INCOMPLETE
-                }
-                1 -> when (it) {
-                    in 0..2 -> SubTaskStatus.COMPLETED
-                    3 -> SubTaskStatus.ACTIVE
-                    else -> SubTaskStatus.INCOMPLETE
-                }
-                else -> when (it) {
-                    in 0..4 -> SubTaskStatus.COMPLETED
-                    5 -> SubTaskStatus.ACTIVE
-                    else -> SubTaskStatus.INCOMPLETE
-                }
-            }
-        )
-    }
+fun makeDummyTask(taskId: Int): Task {
+    return Task(
+        id = taskId,
+        title = "課題${taskId + 1}",
+        colorValue = when (taskId % 3) {
+            0 -> 0xfff8dc6c
+            1 -> 0xfff86e6c
+            else -> 0xff6cbef8
+        },
+        deadline = Date()
+    )
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/TaskAndSubTasks.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/TaskAndSubTasks.kt
@@ -1,0 +1,37 @@
+package com.dashimaki_dofu.mytaskmanagement.model
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+
+/**
+ * TaskAndSubTasks
+ *
+ * Created by Yoshiyasu on 2024/02/11
+ */
+
+// 課題 : 子課題 = 1 : N
+class TaskAndSubTasks {
+    @Embedded
+    lateinit var task: Task
+
+    @Relation(parentColumn = "id", entityColumn = "taskId")
+    lateinit var subTasks: List<SubTask>
+
+    // 課題の進捗率: 完了した課題の割合
+    val progressRate: Float
+        get() {
+            if (subTasks.isEmpty()) return 0f
+            return subTasks.count { it.status == SubTaskStatus.COMPLETED } / subTasks.count().toFloat()
+        }
+}
+
+// 「課題と子課題ペア」のダミーデータ
+fun makeDummyAllTaskAndSubTasks(): List<TaskAndSubTasks> {
+    return (0..<20).map {
+        val taskAndSubTasks = TaskAndSubTasks()
+        taskAndSubTasks.task = makeDummyTask(it)
+        taskAndSubTasks.subTasks = makeDummySubTasks(taskId = it)
+        taskAndSubTasks
+    }
+}

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/repository/TaskRepository.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/repository/TaskRepository.kt
@@ -1,0 +1,53 @@
+package com.dashimaki_dofu.mytaskmanagement.repository
+
+import com.dashimaki_dofu.mytaskmanagement.database.TaskDao
+import com.dashimaki_dofu.mytaskmanagement.model.SubTask
+import com.dashimaki_dofu.mytaskmanagement.model.Task
+import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
+
+
+/**
+ * TaskRepository
+ *
+ * Created by Yoshiyasu on 2024/02/10
+ */
+
+interface TaskRepository {
+    suspend fun getAllTaskAndSubTasks(): List<TaskAndSubTasks>
+    suspend fun createTask(task: Task)
+    suspend fun updateTask(task: Task)
+    suspend fun deleteTask(task: Task)
+    suspend fun createSubTask(subTask: SubTask)
+    suspend fun updateSubTask(subTask: SubTask)
+    suspend fun deleteSubTask(subTask: SubTask)
+}
+
+class TaskRepositoryImpl(private val taskDao: TaskDao) : TaskRepository {
+    override suspend fun getAllTaskAndSubTasks(): List<TaskAndSubTasks> {
+        return taskDao.getAllTaskAndSubTasks()
+    }
+
+    override suspend fun createTask(task: Task) {
+        taskDao.insertTask(task)
+    }
+
+    override suspend fun updateTask(task: Task) {
+        taskDao.updateTask(task)
+    }
+
+    override suspend fun deleteTask(task: Task) {
+        taskDao.deleteTask(task)
+    }
+
+    override suspend fun createSubTask(subTask: SubTask) {
+        taskDao.insertSubTask(subTask)
+    }
+
+    override suspend fun updateSubTask(subTask: SubTask) {
+        taskDao.updateSubTask(subTask)
+    }
+
+    override suspend fun deleteSubTask(subTask: SubTask) {
+        taskDao.deleteSubTask(subTask)
+    }
+}

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/activity/MainActivity.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/activity/MainActivity.kt
@@ -38,9 +38,12 @@ class MainActivity : ComponentActivity() {
                     composable(
                         route = NavLinks.TaskList.route
                     ) {
-                        TaskListScreen(tasks = viewModel.tasks, onClickItem = { taskId ->
-                            navController.navigate(NavLinks.TaskDetail.createRoute(taskId))
-                        })
+                        TaskListScreen(
+                            allTaskAndSubTasks = viewModel.taskAndSubTasks,
+                            onClickItem = { taskId ->
+                                navController.navigate(NavLinks.TaskDetail.createRoute(taskId))
+                            }
+                        )
                     }
 
                     // 課題詳細画面
@@ -53,10 +56,10 @@ class MainActivity : ComponentActivity() {
                         )
                     ) { backStackEntry ->
                         val taskId = backStackEntry.arguments?.getInt(NavLinks.TaskDetail.ARGUMENT_ID) ?: -1
-                        val task = viewModel.tasks.first {
-                            it.id == taskId
+                        val task = viewModel.taskAndSubTasks.first {
+                            it.task.id == taskId
                         }
-                        TaskDetailScreen(task = task, onClickNavigationIcon = {
+                        TaskDetailScreen(taskAndSubTasks = task, onClickNavigationIcon = {
                             navController.navigateUp()
                         })
                     }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskList.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskList.kt
@@ -10,8 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.dashimaki_dofu.mytaskmanagement.model.Task
-import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTasks
+import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
 
 
 /**
@@ -21,17 +21,17 @@ import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTasks
  */
 
 @Composable
-fun TaskList(tasks: List<Task>, onClickItem: (id: Int) -> Unit) {
+fun TaskList(allTaskAndSubTasks: List<TaskAndSubTasks>, onClickItem: (id: Int) -> Unit) {
     LazyColumn(
         modifier = Modifier
             .padding(all = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         items(
-            tasks,
-            key = { task -> task.id }
+            allTaskAndSubTasks,
+            key = { taskAndSubTasks -> taskAndSubTasks.task.id }
         ) { task ->
-            TaskListItem(task = task, onClick = onClickItem)
+            TaskListItem(taskAndSubTasks = task, onClick = onClickItem)
         }
 
         item {
@@ -43,5 +43,5 @@ fun TaskList(tasks: List<Task>, onClickItem: (id: Int) -> Unit) {
 @Preview(showSystemUi = true)
 @Composable
 fun TaskListPreview() {
-    TaskList(makeDummyTasks(), onClickItem = { })
+    TaskList(makeDummyAllTaskAndSubTasks(), onClickItem = { })
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
@@ -28,8 +28,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.dashimaki_dofu.mytaskmanagement.R
-import com.dashimaki_dofu.mytaskmanagement.model.Task
-import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTasks
+import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
 
 
 /**
@@ -39,11 +39,11 @@ import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTasks
  */
 
 @Composable
-fun TaskListItem(task: Task, onClick: (id: Int) -> Unit) {
+fun TaskListItem(taskAndSubTasks: TaskAndSubTasks, onClick: (id: Int) -> Unit) {
     Box(
         modifier = Modifier
             .clickable {
-                onClick(task.id)
+                onClick(taskAndSubTasks.task.id)
             }
             .height(60.dp)
             .shadow(
@@ -51,7 +51,7 @@ fun TaskListItem(task: Task, onClick: (id: Int) -> Unit) {
                 shape = RoundedCornerShape(8.dp)
             )
             .background(
-                task.color.copy(alpha = 0.3f)
+                taskAndSubTasks.task.color.copy(alpha = 0.3f)
                     .compositeOver(Color.White)
             )
         ,
@@ -63,8 +63,8 @@ fun TaskListItem(task: Task, onClick: (id: Int) -> Unit) {
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
-                    .background(task.color)
-                    .fillMaxWidth(task.progressRate)
+                    .background(taskAndSubTasks.task.color)
+                    .fillMaxWidth(taskAndSubTasks.progressRate)
                     .constrainAs(progressBarRef) {}
             )
             Box(
@@ -81,9 +81,9 @@ fun TaskListItem(task: Task, onClick: (id: Int) -> Unit) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Spacer(modifier = Modifier.width(40.dp))
                         Text(
-                            text = task.title,
+                            text = taskAndSubTasks.task.title,
                             fontSize = 24.sp,
-                            color = task.listTitleColor
+                            color = taskAndSubTasks.task.listTitleColor
                         )
                     }
                     Column(
@@ -96,7 +96,7 @@ fun TaskListItem(task: Task, onClick: (id: Int) -> Unit) {
                         )
                         Text(
                             textAlign = TextAlign.Center,
-                            text = task.formattedDeadLineString,
+                            text = taskAndSubTasks.task.formattedDeadLineString,
                             fontSize = 20.sp,
                             fontWeight = FontWeight.Bold,
                             color = Color.Red
@@ -105,7 +105,7 @@ fun TaskListItem(task: Task, onClick: (id: Int) -> Unit) {
                 }
             }
             Text(
-                text = "${(task.progressRate * 100).toInt()}%",
+                text = "${(taskAndSubTasks.progressRate * 100).toInt()}%",
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Bold,
                 color = colorResource(id = R.color.lightGray1),
@@ -122,7 +122,7 @@ fun TaskListItem(task: Task, onClick: (id: Int) -> Unit) {
 @Composable
 fun TaskListItemPreview() {
     TaskListItem(
-        task = makeDummyTasks().first(),
+        taskAndSubTasks = makeDummyAllTaskAndSubTasks().first(),
         onClick = { }
     )
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
@@ -42,9 +42,9 @@ import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.dashimaki_dofu.mytaskmanagement.R
 import com.dashimaki_dofu.mytaskmanagement.model.SubTask
-import com.dashimaki_dofu.mytaskmanagement.model.Task
+import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
 import com.dashimaki_dofu.mytaskmanagement.model.makeDummySubTasks
-import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTasks
 
 
 /**
@@ -55,7 +55,7 @@ import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTasks
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TaskDetailScreen(task: Task, onClickNavigationIcon: () -> Unit) {
+fun TaskDetailScreen(taskAndSubTasks: TaskAndSubTasks, onClickNavigationIcon: () -> Unit) {
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
@@ -64,7 +64,7 @@ fun TaskDetailScreen(task: Task, onClickNavigationIcon: () -> Unit) {
             topBar = {
                 TopAppBar(
                     title = {
-                        Text(task.title)
+                        Text(taskAndSubTasks.task.title)
                     },
                     colors = TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -92,7 +92,7 @@ fun TaskDetailScreen(task: Task, onClickNavigationIcon: () -> Unit) {
                             shape = RoundedCornerShape(8.dp)
                         )
                         .background(
-                            task.color
+                            taskAndSubTasks.task.color
                                 .copy(alpha = 0.3f)
                                 .compositeOver(Color.White)
                         )
@@ -105,7 +105,7 @@ fun TaskDetailScreen(task: Task, onClickNavigationIcon: () -> Unit) {
                     ) {
                         Row {
                             Text(
-                                text = "締切: ${task.formattedDeadLineString}",
+                                text = "締切: ${taskAndSubTasks.task.formattedDeadLineString}",
                                 color = Color.Red,
                                 fontWeight = FontWeight.Bold,
                                 fontSize = 28.sp
@@ -117,7 +117,7 @@ fun TaskDetailScreen(task: Task, onClickNavigationIcon: () -> Unit) {
                                 .height(60.dp)
                                 .border(
                                     width = 4.dp,
-                                    color = task.color,
+                                    color = taskAndSubTasks.task.color,
                                     shape = RoundedCornerShape(12.dp)
                                 )
                                 .fillMaxWidth()
@@ -126,7 +126,7 @@ fun TaskDetailScreen(task: Task, onClickNavigationIcon: () -> Unit) {
 
                             Box(
                                 modifier = Modifier
-                                    .fillMaxWidth(task.progressRate)
+                                    .fillMaxWidth(taskAndSubTasks.progressRate)
                                     .fillMaxHeight()
                                     .border(
                                         width = 0.dp,
@@ -137,7 +137,7 @@ fun TaskDetailScreen(task: Task, onClickNavigationIcon: () -> Unit) {
                                         )
                                     )
                                     .background(
-                                        color = task.color,
+                                        color = taskAndSubTasks.task.color,
                                         shape = RoundedCornerShape(
                                             topStart = 12.dp,
                                             bottomStart = 12.dp
@@ -146,7 +146,7 @@ fun TaskDetailScreen(task: Task, onClickNavigationIcon: () -> Unit) {
                                     .constrainAs(progressBarRef) {}
                             )
                             Text(
-                                text = "${(task.progressRate * 100).toInt()}%",
+                                text = "${(taskAndSubTasks.progressRate * 100).toInt()}%",
                                 fontSize = 20.sp,
                                 fontWeight = FontWeight.Bold,
                                 color = colorResource(id = R.color.lightGray1),
@@ -159,7 +159,7 @@ fun TaskDetailScreen(task: Task, onClickNavigationIcon: () -> Unit) {
                         }
                         Spacer(modifier = Modifier.height(8.dp))
                         LazyColumn {
-                            items(task.subTasks) { subTask ->
+                            items(taskAndSubTasks.subTasks) { subTask ->
                                 SubTaskListItem(subTask = subTask)
                             }
                         }
@@ -209,7 +209,10 @@ fun SubTaskListItem(subTask: SubTask) {
 @Preview(showBackground = true)
 @Composable
 fun TaskDetailScreenPreview() {
-    TaskDetailScreen(task = makeDummyTasks().first(), onClickNavigationIcon = {})
+    TaskDetailScreen(
+        taskAndSubTasks = makeDummyAllTaskAndSubTasks().first(),
+        onClickNavigationIcon = {}
+    )
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskListScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskListScreen.kt
@@ -13,8 +13,8 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.dashimaki_dofu.mytaskmanagement.model.Task
-import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTasks
+import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
 import com.dashimaki_dofu.mytaskmanagement.view.composable.TaskList
 
 
@@ -26,7 +26,7 @@ import com.dashimaki_dofu.mytaskmanagement.view.composable.TaskList
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TaskListScreen(tasks: List<Task>, onClickItem: (id: Int) -> Unit) {
+fun TaskListScreen(allTaskAndSubTasks: List<TaskAndSubTasks>, onClickItem: (id: Int) -> Unit) {
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
@@ -45,7 +45,7 @@ fun TaskListScreen(tasks: List<Task>, onClickItem: (id: Int) -> Unit) {
             }
         ) { innerPadding ->
             Box(modifier = Modifier.padding(innerPadding)) {
-                TaskList(tasks = tasks, onClickItem = onClickItem)
+                TaskList(allTaskAndSubTasks = allTaskAndSubTasks, onClickItem = onClickItem)
             }
         }
     }
@@ -54,5 +54,5 @@ fun TaskListScreen(tasks: List<Task>, onClickItem: (id: Int) -> Unit) {
 @Preview(showBackground = true)
 @Composable
 fun TaskListScreenPreview() {
-    TaskListScreen(tasks = makeDummyTasks(), onClickItem = {})
+    TaskListScreen(allTaskAndSubTasks = makeDummyAllTaskAndSubTasks(), onClickItem = {})
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/viewModel/MainViewModel.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/viewModel/MainViewModel.kt
@@ -2,8 +2,8 @@ package com.dashimaki_dofu.mytaskmanagement.viewModel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.dashimaki_dofu.mytaskmanagement.model.Task
-import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTasks
+import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,7 +20,7 @@ class MainViewModel : ViewModel() {
     private val _loading = MutableStateFlow(true)
     val loading = _loading.asStateFlow()
 
-    val tasks: List<Task> by lazy { makeDummyTasks() }
+    val taskAndSubTasks: List<TaskAndSubTasks> by lazy { makeDummyAllTaskAndSubTasks() }
 
     init {
         viewModelScope.launch {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 05 21:10:21 JST 2024
+#Sat Feb 10 21:02:22 JST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Overview
- Roomを導入し、課題・子課題モデルをEntity化する

## Implement Overview
- Gradleバージョンのアップデート
  - 8.2 -> 8.6
- Roomの導入
- `Task` `SubTask` をEntity化
- `Task : SubTask` に `1:N` のリレーションを張り、そのラッパークラスである `TaskAndSubTasks` を実装
  - 命名についてはもっと良いのを考える
- `TaskDao` の実装
- `TaskDatabase` の実装
- `RoomApplication` を実装し、マニフェストに適用
- `TaskRepository` の実装
- 既存のComposableをEntity化したモデルに対応

## Screen Shots
なし

## Related Issues
#3 
