### PR TITLE
ci: 🎡 add workflow: `auto-approve`

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,18 @@
+name: Auto Approve
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+jobs:
+  approve:
+    if: |
+      github.event.pull_request.user.login == github.repository_owner
+      && ! github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v3


### PR DESCRIPTION
## Overview
- `auto-approve` の導入
  - コードオーナーかつコントリビュータが1人であってもPRのレビューができないため、botにapproveしてもらう。

## Implement Overview
- `auto-approve.yml`の追加

## Screen Shots
なし

## Related Issues
なし
