### PR TITLE
refactor: 💡 rename: `TaskAndSubTasks` -> `TaskSubject`

### DIFF
--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/database/TaskDatabase.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/database/TaskDatabase.kt
@@ -26,5 +26,5 @@ abstract class TaskDatabase : RoomDatabase() {
     companion object {
         const val DATABASE_NAME = "tasks"
     }
-    abstract fun taskDao(): TaskDao
+    abstract fun taskSubjectDao(): TaskSubjectDao
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/database/TaskSubjectDao.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/database/TaskSubjectDao.kt
@@ -9,20 +9,20 @@ import androidx.room.Transaction
 import androidx.room.Update
 import com.dashimaki_dofu.mytaskmanagement.model.SubTask
 import com.dashimaki_dofu.mytaskmanagement.model.Task
-import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
 
 
 /**
- * TaskDao
+ * TaskSubjectDao
  *
  * Created by Yoshiyasu on 2024/02/10
  */
 
 @Dao
-interface TaskDao {
+interface TaskSubjectDao {
     @Transaction
     @Query("select * from tasks")
-    suspend fun getAllTaskAndSubTasks(): List<TaskAndSubTasks>
+    suspend fun getAllTaskSubjects(): List<TaskSubject>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertTask(task: Task)

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/DummyModels.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/DummyModels.kt
@@ -1,0 +1,62 @@
+package com.dashimaki_dofu.mytaskmanagement.model
+
+import java.util.Date
+
+
+/**
+ * DummyModels
+ *
+ * Created by Yoshiyasu on 2024/02/12
+ */
+
+// ダミーの課題ラッパー: デバッグ用
+fun makeDummyTaskSubjects(): List<TaskSubject> {
+    return (0..<20).map {
+        val taskSubject = TaskSubject()
+        taskSubject.task = makeDummyTask(it)
+        taskSubject.subTasks = makeDummySubTasks(taskId = it)
+        taskSubject
+    }
+}
+
+// ダミーの課題: デバッグ用
+fun makeDummyTask(taskId: Int): Task {
+    return Task(
+        id = taskId,
+        title = "課題${taskId + 1}",
+        colorValue = when (taskId % 3) {
+            0 -> 0xfff8dc6c
+            1 -> 0xfff86e6c
+            else -> 0xff6cbef8
+        },
+        deadline = Date()
+    )
+}
+
+// ダミーの子課題リスト: デバッグ用
+fun makeDummySubTasks(taskId: Int = 0): List<SubTask> {
+    return (0..<10).map {
+        SubTask(
+            id = it,
+            taskId = taskId,
+            title = "課題${taskId + 1}の子課題${it + 1}",
+            status = when (taskId % 3) {
+                0 -> when (it) {
+                    in 0..1 -> SubTaskStatus.COMPLETED
+                    2 -> SubTaskStatus.ACTIVE
+                    else -> SubTaskStatus.INCOMPLETE
+                }
+                1 -> when (it) {
+                    in 0..2 -> SubTaskStatus.COMPLETED
+                    3 -> SubTaskStatus.ACTIVE
+                    else -> SubTaskStatus.INCOMPLETE
+                }
+                else -> when (it) {
+                    in 0..4 -> SubTaskStatus.COMPLETED
+                    5 -> SubTaskStatus.ACTIVE
+                    else -> SubTaskStatus.INCOMPLETE
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/SubTask.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/SubTask.kt
@@ -46,31 +46,3 @@ enum class SubTaskStatus {
     ACTIVE,     // 着手中
     COMPLETED,  // 完了
 }
-
-// ダミーの子課題リスト: デバッグ用
-fun makeDummySubTasks(taskId: Int = 0): List<SubTask> {
-    return (0..<10).map {
-        SubTask(
-            id = it,
-            taskId = taskId,
-            title = "課題${taskId + 1}の子課題${it + 1}",
-            status = when (taskId % 3) {
-                0 -> when (it) {
-                    in 0..1 -> SubTaskStatus.COMPLETED
-                    2 -> SubTaskStatus.ACTIVE
-                    else -> SubTaskStatus.INCOMPLETE
-                }
-                1 -> when (it) {
-                    in 0..2 -> SubTaskStatus.COMPLETED
-                    3 -> SubTaskStatus.ACTIVE
-                    else -> SubTaskStatus.INCOMPLETE
-                }
-                else -> when (it) {
-                    in 0..4 -> SubTaskStatus.COMPLETED
-                    5 -> SubTaskStatus.ACTIVE
-                    else -> SubTaskStatus.INCOMPLETE
-                }
-            }
-        )
-    }
-}

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/Task.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/Task.kt
@@ -51,21 +51,3 @@ data class Task(
             return Color(ColorUtils.HSLToColor(hsl).toColor().toArgb())
         }
 }
-
-// ダミーの課題リスト: デバッグ用
-fun makeDummyTasks(numberOfTask: Int = 20): List<Task> {
-    return (0..<numberOfTask).map { makeDummyTask(it) }
-}
-
-fun makeDummyTask(taskId: Int): Task {
-    return Task(
-        id = taskId,
-        title = "課題${taskId + 1}",
-        colorValue = when (taskId % 3) {
-            0 -> 0xfff8dc6c
-            1 -> 0xfff86e6c
-            else -> 0xff6cbef8
-        },
-        deadline = Date()
-    )
-}

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/TaskSubject.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/TaskSubject.kt
@@ -5,13 +5,13 @@ import androidx.room.Relation
 
 
 /**
- * TaskAndSubTasks
+ * TaskSubject
  *
  * Created by Yoshiyasu on 2024/02/11
  */
 
-// 課題 : 子課題 = 1 : N
-class TaskAndSubTasks {
+// 「課題 : 子課題 = 1 : N」のリレーションを実現するラッパーオブジェクト
+class TaskSubject {
     @Embedded
     lateinit var task: Task
 
@@ -24,14 +24,4 @@ class TaskAndSubTasks {
             if (subTasks.isEmpty()) return 0f
             return subTasks.count { it.status == SubTaskStatus.COMPLETED } / subTasks.count().toFloat()
         }
-}
-
-// 「課題と子課題ペア」のダミーデータ
-fun makeDummyAllTaskAndSubTasks(): List<TaskAndSubTasks> {
-    return (0..<20).map {
-        val taskAndSubTasks = TaskAndSubTasks()
-        taskAndSubTasks.task = makeDummyTask(it)
-        taskAndSubTasks.subTasks = makeDummySubTasks(taskId = it)
-        taskAndSubTasks
-    }
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/repository/TaskSubjectRepository.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/repository/TaskSubjectRepository.kt
@@ -1,19 +1,19 @@
 package com.dashimaki_dofu.mytaskmanagement.repository
 
-import com.dashimaki_dofu.mytaskmanagement.database.TaskDao
+import com.dashimaki_dofu.mytaskmanagement.database.TaskSubjectDao
 import com.dashimaki_dofu.mytaskmanagement.model.SubTask
 import com.dashimaki_dofu.mytaskmanagement.model.Task
-import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
 
 
 /**
- * TaskRepository
+ * TaskSubjectRepository
  *
  * Created by Yoshiyasu on 2024/02/10
  */
 
-interface TaskRepository {
-    suspend fun getAllTaskAndSubTasks(): List<TaskAndSubTasks>
+interface TaskSubjectRepository {
+    suspend fun getAllTaskSubjects(): List<TaskSubject>
     suspend fun createTask(task: Task)
     suspend fun updateTask(task: Task)
     suspend fun deleteTask(task: Task)
@@ -22,32 +22,34 @@ interface TaskRepository {
     suspend fun deleteSubTask(subTask: SubTask)
 }
 
-class TaskRepositoryImpl(private val taskDao: TaskDao) : TaskRepository {
-    override suspend fun getAllTaskAndSubTasks(): List<TaskAndSubTasks> {
-        return taskDao.getAllTaskAndSubTasks()
+class TaskSubjectRepositoryImpl(
+    private val taskSubjectDao: TaskSubjectDao
+) : TaskSubjectRepository {
+    override suspend fun getAllTaskSubjects(): List<TaskSubject> {
+        return taskSubjectDao.getAllTaskSubjects()
     }
 
     override suspend fun createTask(task: Task) {
-        taskDao.insertTask(task)
+        taskSubjectDao.insertTask(task)
     }
 
     override suspend fun updateTask(task: Task) {
-        taskDao.updateTask(task)
+        taskSubjectDao.updateTask(task)
     }
 
     override suspend fun deleteTask(task: Task) {
-        taskDao.deleteTask(task)
+        taskSubjectDao.deleteTask(task)
     }
 
     override suspend fun createSubTask(subTask: SubTask) {
-        taskDao.insertSubTask(subTask)
+        taskSubjectDao.insertSubTask(subTask)
     }
 
     override suspend fun updateSubTask(subTask: SubTask) {
-        taskDao.updateSubTask(subTask)
+        taskSubjectDao.updateSubTask(subTask)
     }
 
     override suspend fun deleteSubTask(subTask: SubTask) {
-        taskDao.deleteSubTask(subTask)
+        taskSubjectDao.deleteSubTask(subTask)
     }
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/activity/MainActivity.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/activity/MainActivity.kt
@@ -39,7 +39,7 @@ class MainActivity : ComponentActivity() {
                         route = NavLinks.TaskList.route
                     ) {
                         TaskListScreen(
-                            allTaskAndSubTasks = viewModel.taskAndSubTasks,
+                            taskSubjects = viewModel.taskSubjects,
                             onClickItem = { taskId ->
                                 navController.navigate(NavLinks.TaskDetail.createRoute(taskId))
                             }
@@ -56,10 +56,10 @@ class MainActivity : ComponentActivity() {
                         )
                     ) { backStackEntry ->
                         val taskId = backStackEntry.arguments?.getInt(NavLinks.TaskDetail.ARGUMENT_ID) ?: -1
-                        val task = viewModel.taskAndSubTasks.first {
+                        val task = viewModel.taskSubjects.first {
                             it.task.id == taskId
                         }
-                        TaskDetailScreen(taskAndSubTasks = task, onClickNavigationIcon = {
+                        TaskDetailScreen(taskSubject = task, onClickNavigationIcon = {
                             navController.navigateUp()
                         })
                     }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskList.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskList.kt
@@ -10,8 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
 import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
+import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTaskSubjects
 
 
 /**

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskList.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskList.kt
@@ -10,8 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
 import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
 
 
 /**
@@ -21,17 +21,17 @@ import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
  */
 
 @Composable
-fun TaskList(allTaskAndSubTasks: List<TaskAndSubTasks>, onClickItem: (id: Int) -> Unit) {
+fun TaskList(taskSubjects: List<TaskSubject>, onClickItem: (id: Int) -> Unit) {
     LazyColumn(
         modifier = Modifier
             .padding(all = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         items(
-            allTaskAndSubTasks,
-            key = { taskAndSubTasks -> taskAndSubTasks.task.id }
+            taskSubjects,
+            key = { taskSubject -> taskSubject.task.id }
         ) { task ->
-            TaskListItem(taskAndSubTasks = task, onClick = onClickItem)
+            TaskListItem(taskSubject = task, onClick = onClickItem)
         }
 
         item {
@@ -43,5 +43,5 @@ fun TaskList(allTaskAndSubTasks: List<TaskAndSubTasks>, onClickItem: (id: Int) -
 @Preview(showSystemUi = true)
 @Composable
 fun TaskListPreview() {
-    TaskList(makeDummyAllTaskAndSubTasks(), onClickItem = { })
+    TaskList(makeDummyTaskSubjects(), onClickItem = { })
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
@@ -28,8 +28,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.dashimaki_dofu.mytaskmanagement.R
-import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
 import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
+import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTaskSubjects
 
 
 /**

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
@@ -28,8 +28,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.dashimaki_dofu.mytaskmanagement.R
-import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
 import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
 
 
 /**
@@ -39,11 +39,11 @@ import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
  */
 
 @Composable
-fun TaskListItem(taskAndSubTasks: TaskAndSubTasks, onClick: (id: Int) -> Unit) {
+fun TaskListItem(taskSubject: TaskSubject, onClick: (id: Int) -> Unit) {
     Box(
         modifier = Modifier
             .clickable {
-                onClick(taskAndSubTasks.task.id)
+                onClick(taskSubject.task.id)
             }
             .height(60.dp)
             .shadow(
@@ -51,7 +51,7 @@ fun TaskListItem(taskAndSubTasks: TaskAndSubTasks, onClick: (id: Int) -> Unit) {
                 shape = RoundedCornerShape(8.dp)
             )
             .background(
-                taskAndSubTasks.task.color.copy(alpha = 0.3f)
+                taskSubject.task.color.copy(alpha = 0.3f)
                     .compositeOver(Color.White)
             )
         ,
@@ -63,8 +63,8 @@ fun TaskListItem(taskAndSubTasks: TaskAndSubTasks, onClick: (id: Int) -> Unit) {
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
-                    .background(taskAndSubTasks.task.color)
-                    .fillMaxWidth(taskAndSubTasks.progressRate)
+                    .background(taskSubject.task.color)
+                    .fillMaxWidth(taskSubject.progressRate)
                     .constrainAs(progressBarRef) {}
             )
             Box(
@@ -81,9 +81,9 @@ fun TaskListItem(taskAndSubTasks: TaskAndSubTasks, onClick: (id: Int) -> Unit) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Spacer(modifier = Modifier.width(40.dp))
                         Text(
-                            text = taskAndSubTasks.task.title,
+                            text = taskSubject.task.title,
                             fontSize = 24.sp,
-                            color = taskAndSubTasks.task.listTitleColor
+                            color = taskSubject.task.listTitleColor
                         )
                     }
                     Column(
@@ -96,7 +96,7 @@ fun TaskListItem(taskAndSubTasks: TaskAndSubTasks, onClick: (id: Int) -> Unit) {
                         )
                         Text(
                             textAlign = TextAlign.Center,
-                            text = taskAndSubTasks.task.formattedDeadLineString,
+                            text = taskSubject.task.formattedDeadLineString,
                             fontSize = 20.sp,
                             fontWeight = FontWeight.Bold,
                             color = Color.Red
@@ -105,7 +105,7 @@ fun TaskListItem(taskAndSubTasks: TaskAndSubTasks, onClick: (id: Int) -> Unit) {
                 }
             }
             Text(
-                text = "${(taskAndSubTasks.progressRate * 100).toInt()}%",
+                text = "${(taskSubject.progressRate * 100).toInt()}%",
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Bold,
                 color = colorResource(id = R.color.lightGray1),
@@ -122,7 +122,7 @@ fun TaskListItem(taskAndSubTasks: TaskAndSubTasks, onClick: (id: Int) -> Unit) {
 @Composable
 fun TaskListItemPreview() {
     TaskListItem(
-        taskAndSubTasks = makeDummyAllTaskAndSubTasks().first(),
+        taskSubject = makeDummyTaskSubjects().first(),
         onClick = { }
     )
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
@@ -42,9 +42,9 @@ import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.dashimaki_dofu.mytaskmanagement.R
 import com.dashimaki_dofu.mytaskmanagement.model.SubTask
-import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
 import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
 import com.dashimaki_dofu.mytaskmanagement.model.makeDummySubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTaskSubjects
 
 
 /**

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
@@ -42,8 +42,8 @@ import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.dashimaki_dofu.mytaskmanagement.R
 import com.dashimaki_dofu.mytaskmanagement.model.SubTask
-import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
 import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
 import com.dashimaki_dofu.mytaskmanagement.model.makeDummySubTasks
 
 
@@ -55,7 +55,7 @@ import com.dashimaki_dofu.mytaskmanagement.model.makeDummySubTasks
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TaskDetailScreen(taskAndSubTasks: TaskAndSubTasks, onClickNavigationIcon: () -> Unit) {
+fun TaskDetailScreen(taskSubject: TaskSubject, onClickNavigationIcon: () -> Unit) {
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
@@ -64,7 +64,7 @@ fun TaskDetailScreen(taskAndSubTasks: TaskAndSubTasks, onClickNavigationIcon: ()
             topBar = {
                 TopAppBar(
                     title = {
-                        Text(taskAndSubTasks.task.title)
+                        Text(taskSubject.task.title)
                     },
                     colors = TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -92,7 +92,7 @@ fun TaskDetailScreen(taskAndSubTasks: TaskAndSubTasks, onClickNavigationIcon: ()
                             shape = RoundedCornerShape(8.dp)
                         )
                         .background(
-                            taskAndSubTasks.task.color
+                            taskSubject.task.color
                                 .copy(alpha = 0.3f)
                                 .compositeOver(Color.White)
                         )
@@ -105,7 +105,7 @@ fun TaskDetailScreen(taskAndSubTasks: TaskAndSubTasks, onClickNavigationIcon: ()
                     ) {
                         Row {
                             Text(
-                                text = "締切: ${taskAndSubTasks.task.formattedDeadLineString}",
+                                text = "締切: ${taskSubject.task.formattedDeadLineString}",
                                 color = Color.Red,
                                 fontWeight = FontWeight.Bold,
                                 fontSize = 28.sp
@@ -117,7 +117,7 @@ fun TaskDetailScreen(taskAndSubTasks: TaskAndSubTasks, onClickNavigationIcon: ()
                                 .height(60.dp)
                                 .border(
                                     width = 4.dp,
-                                    color = taskAndSubTasks.task.color,
+                                    color = taskSubject.task.color,
                                     shape = RoundedCornerShape(12.dp)
                                 )
                                 .fillMaxWidth()
@@ -126,7 +126,7 @@ fun TaskDetailScreen(taskAndSubTasks: TaskAndSubTasks, onClickNavigationIcon: ()
 
                             Box(
                                 modifier = Modifier
-                                    .fillMaxWidth(taskAndSubTasks.progressRate)
+                                    .fillMaxWidth(taskSubject.progressRate)
                                     .fillMaxHeight()
                                     .border(
                                         width = 0.dp,
@@ -137,7 +137,7 @@ fun TaskDetailScreen(taskAndSubTasks: TaskAndSubTasks, onClickNavigationIcon: ()
                                         )
                                     )
                                     .background(
-                                        color = taskAndSubTasks.task.color,
+                                        color = taskSubject.task.color,
                                         shape = RoundedCornerShape(
                                             topStart = 12.dp,
                                             bottomStart = 12.dp
@@ -146,7 +146,7 @@ fun TaskDetailScreen(taskAndSubTasks: TaskAndSubTasks, onClickNavigationIcon: ()
                                     .constrainAs(progressBarRef) {}
                             )
                             Text(
-                                text = "${(taskAndSubTasks.progressRate * 100).toInt()}%",
+                                text = "${(taskSubject.progressRate * 100).toInt()}%",
                                 fontSize = 20.sp,
                                 fontWeight = FontWeight.Bold,
                                 color = colorResource(id = R.color.lightGray1),
@@ -159,7 +159,7 @@ fun TaskDetailScreen(taskAndSubTasks: TaskAndSubTasks, onClickNavigationIcon: ()
                         }
                         Spacer(modifier = Modifier.height(8.dp))
                         LazyColumn {
-                            items(taskAndSubTasks.subTasks) { subTask ->
+                            items(taskSubject.subTasks) { subTask ->
                                 SubTaskListItem(subTask = subTask)
                             }
                         }
@@ -210,7 +210,7 @@ fun SubTaskListItem(subTask: SubTask) {
 @Composable
 fun TaskDetailScreenPreview() {
     TaskDetailScreen(
-        taskAndSubTasks = makeDummyAllTaskAndSubTasks().first(),
+        taskSubject = makeDummyTaskSubjects().first(),
         onClickNavigationIcon = {}
     )
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskListScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskListScreen.kt
@@ -13,8 +13,8 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
 import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
+import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTaskSubjects
 import com.dashimaki_dofu.mytaskmanagement.view.composable.TaskList
 
 

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskListScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskListScreen.kt
@@ -13,8 +13,8 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
 import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
 import com.dashimaki_dofu.mytaskmanagement.view.composable.TaskList
 
 
@@ -26,7 +26,7 @@ import com.dashimaki_dofu.mytaskmanagement.view.composable.TaskList
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TaskListScreen(allTaskAndSubTasks: List<TaskAndSubTasks>, onClickItem: (id: Int) -> Unit) {
+fun TaskListScreen(taskSubjects: List<TaskSubject>, onClickItem: (id: Int) -> Unit) {
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
@@ -45,7 +45,7 @@ fun TaskListScreen(allTaskAndSubTasks: List<TaskAndSubTasks>, onClickItem: (id: 
             }
         ) { innerPadding ->
             Box(modifier = Modifier.padding(innerPadding)) {
-                TaskList(allTaskAndSubTasks = allTaskAndSubTasks, onClickItem = onClickItem)
+                TaskList(taskSubjects = taskSubjects, onClickItem = onClickItem)
             }
         }
     }
@@ -54,5 +54,5 @@ fun TaskListScreen(allTaskAndSubTasks: List<TaskAndSubTasks>, onClickItem: (id: 
 @Preview(showBackground = true)
 @Composable
 fun TaskListScreenPreview() {
-    TaskListScreen(allTaskAndSubTasks = makeDummyAllTaskAndSubTasks(), onClickItem = {})
+    TaskListScreen(taskSubjects = makeDummyTaskSubjects(), onClickItem = {})
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/viewModel/MainViewModel.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/viewModel/MainViewModel.kt
@@ -2,8 +2,8 @@ package com.dashimaki_dofu.mytaskmanagement.viewModel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
 import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
+import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTaskSubjects
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/viewModel/MainViewModel.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/viewModel/MainViewModel.kt
@@ -2,8 +2,8 @@ package com.dashimaki_dofu.mytaskmanagement.viewModel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.dashimaki_dofu.mytaskmanagement.model.TaskAndSubTasks
 import com.dashimaki_dofu.mytaskmanagement.model.makeDummyAllTaskAndSubTasks
+import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,7 +20,7 @@ class MainViewModel : ViewModel() {
     private val _loading = MutableStateFlow(true)
     val loading = _loading.asStateFlow()
 
-    val taskAndSubTasks: List<TaskAndSubTasks> by lazy { makeDummyAllTaskAndSubTasks() }
+    val taskSubjects: List<TaskSubject> by lazy { makeDummyTaskSubjects() }
 
     init {
         viewModelScope.launch {


### PR DESCRIPTION
## Overview
- `TaskAndSubTask` の再命名 -> `TaskSubject`

## Implement Overview
- `TaskAndSubTask` を `TaskSubject` にリネーム
  - 関連する変数名・引数名もリネーム
- ダミーデータ生成メソッドを独立ファイルに切り出し

## Screen Shots
なし

## Related Issues
なし
