### PR TITLE
refactor: 💡 `MainScreen` divided into other file

### DIFF
--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/activity/MainActivity.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/activity/MainActivity.kt
@@ -5,15 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.navigation.NavType
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
-import com.dashimaki_dofu.mytaskmanagement.NavLinks
-import com.dashimaki_dofu.mytaskmanagement.ui.theme.MyTaskManagementTheme
-import com.dashimaki_dofu.mytaskmanagement.view.composable.screen.TaskDetailScreen
-import com.dashimaki_dofu.mytaskmanagement.view.composable.screen.TaskListScreen
+import com.dashimaki_dofu.mytaskmanagement.view.composable.screen.MainScreen
 import com.dashimaki_dofu.mytaskmanagement.viewModel.MainViewModel
 
 class MainActivity : ComponentActivity() {
@@ -28,43 +20,7 @@ class MainActivity : ComponentActivity() {
         }
 
         setContent {
-            MyTaskManagementTheme {
-                val navController = rememberNavController()
-                NavHost(
-                    navController = navController,
-                    startDestination = NavLinks.TaskList.route,
-                ) {
-                    // 課題一覧画面
-                    composable(
-                        route = NavLinks.TaskList.route
-                    ) {
-                        TaskListScreen(
-                            taskSubjects = viewModel.taskSubjects,
-                            onClickItem = { taskId ->
-                                navController.navigate(NavLinks.TaskDetail.createRoute(taskId))
-                            }
-                        )
-                    }
-
-                    // 課題詳細画面
-                    composable(
-                        route = NavLinks.TaskDetail.route,
-                        arguments = listOf(
-                            navArgument(NavLinks.TaskDetail.ARGUMENT_ID) {
-                                type = NavType.IntType
-                            }
-                        )
-                    ) { backStackEntry ->
-                        val taskId = backStackEntry.arguments?.getInt(NavLinks.TaskDetail.ARGUMENT_ID) ?: -1
-                        val task = viewModel.taskSubjects.first {
-                            it.task.id == taskId
-                        }
-                        TaskDetailScreen(taskSubject = task, onClickNavigationIcon = {
-                            navController.navigateUp()
-                        })
-                    }
-                }
-            }
+            MainScreen(viewModel = viewModel)
         }
     }
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/MainScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/MainScreen.kt
@@ -1,0 +1,66 @@
+package com.dashimaki_dofu.mytaskmanagement.view.composable.screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.dashimaki_dofu.mytaskmanagement.NavLinks
+import com.dashimaki_dofu.mytaskmanagement.ui.theme.MyTaskManagementTheme
+import com.dashimaki_dofu.mytaskmanagement.viewModel.MainViewModel
+
+
+/**
+ * MainScreen
+ *
+ * Created by Yoshiyasu on 2024/02/13
+ */
+
+@Composable
+fun MainScreen(viewModel: MainViewModel) {
+    MyTaskManagementTheme {
+        val navController = rememberNavController()
+        NavHost(
+            navController = navController,
+            startDestination = NavLinks.TaskList.route,
+        ) {
+            // 課題一覧画面
+            composable(
+                route = NavLinks.TaskList.route
+            ) {
+                TaskListScreen(
+                    taskSubjects = viewModel.taskSubjects,
+                    onClickItem = { taskId ->
+                        navController.navigate(NavLinks.TaskDetail.createRoute(taskId))
+                    }
+                )
+            }
+
+            // 課題詳細画面
+            composable(
+                route = NavLinks.TaskDetail.route,
+                arguments = listOf(
+                    navArgument(NavLinks.TaskDetail.ARGUMENT_ID) {
+                        type = NavType.IntType
+                    }
+                )
+            ) { backStackEntry ->
+                val taskId = backStackEntry.arguments?.getInt(NavLinks.TaskDetail.ARGUMENT_ID) ?: -1
+                val task = viewModel.taskSubjects.first {
+                    it.task.id == taskId
+                }
+                TaskDetailScreen(taskSubject = task, onClickNavigationIcon = {
+                    navController.navigateUp()
+                })
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MainScreenPreview() {
+    MainScreen(viewModel = MainViewModel())
+}


### PR DESCRIPTION
## Overview
- アプリ起動後に表示するルートViewを `MainScreen()` としてComposableで定義する 

## Implement Overview
- `setContent` 内のComposableを `MainScreen()` のComposableとして定義する

## Screen Shots
なし

## Related Issues
なし
