### PR TITLE
feat: 🎸 delete `android:theme`

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
             android:label="@string/app_name"
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
-            android:theme="@style/Theme.App.First"
             tools:targetApi="31">
         <activity
                 android:name=".view.activity.MainActivity"


### PR DESCRIPTION
## Overview
- ダークモード対応は別で行うため、AndroidManifestの `android:theme` を削除する

## Implement Overview
- AndroidManifest.xmlから `android:theme` を削除

## Screen Shots
なし

## Related Issues
なし
