### PR TITLE
ci: 🎡 add `auto-assign` workflow & call `auto-assign` before `auto-approve`

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,1 @@
+addAssignees: author

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -7,7 +7,10 @@ on:
       - synchronize
       - ready_for_review
 jobs:
+  auto-assign:
+    uses: ./.github/workflows/auto-assign.yml
   approve:
+    needs: auto-assign
     if: |
       github.event.pull_request.user.login == github.repository_owner
       && ! github.event.pull_request.draft

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,9 @@
+name: Auto-Assign
+on:
+  workflow_call:
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0


### PR DESCRIPTION
## Overview
- 自身をassigneeとして設定する手間を省くため `auto-assign` workflowを追加

## Implement Overview
- `auto-assign` workflowを追加
- `auto-approve` 前に `auto-assign` を実行するように

## Screen Shots
なし

## Related Issues
なし
