### PR TITLE
ci: 🎡 add `Deploy To App Distribution` workflow

### DIFF
--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
 
 jobs:
   build:

--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew assembleRelease
 
       - name: Show ./app directory
-        run: ls -l ./app/build
+        run: ls -l ./app/build/outputs
 
       - name: Deploy to App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1

--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew assembleRelease
 
       - name: Show ./app directory
-        run: ls -l ./app/build/outputs/apk
+        run: ls -l ./app/build/outputs/apk/release
 
       - name: Deploy to App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1

--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Grant Permission gradlew
         run: chmod +x gradlew
 
+      - name: Make google-service.json
+        env:
+          GOOGLE_SERVICE: ${{ secrets.GOOGLE_SERVICE_JSON }}
+        run: echo $GOOGLE_SERVICE | base64 --decode --ignore-garbage > ./app/google-services.json
+
       - name: Building Release APK
         env:
           ENV_SIGN_KEYSTORE_BASE64: ${{secrets.ENV_SIGN_KEYSTORE_BASE64}}

--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -32,6 +32,9 @@ jobs:
           ENV_SIGN_STORE_PASSWORD: ${{secrets.ENV_SIGN_STORE_PASSWORD}}
         run: ./gradlew assembleRelease
 
+      - name: Find APK Location
+        run: find ./ -name app-release.apk
+
       - name: Deploy to App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:

--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -1,0 +1,41 @@
+name: Deploy To App Distribution
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # テストでdevelop指定
+          ref: 'develop'
+
+      - name: set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant Permission gradlew
+        run: chmod +x gradlew
+
+      - name: Building Release APK
+        env:
+          ENV_SIGN_KEYSTORE_BASE64: ${{secrets.ENV_SIGN_KEYSTORE_BASE64}}
+          ENV_SIGN_KEY_ALIAS: ${{secrets.ENV_SIGN_KEY_ALIAS}}
+          ENV_SIGN_KEY_PASSWORD: ${{secrets.ENV_SIGN_KEY_PASSWORD}}
+          ENV_SIGN_STORE_PASSWORD: ${{secrets.ENV_SIGN_STORE_PASSWORD}}
+        run: ./gradlew assembleRelease
+
+      - name: Deploy to App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
+          groups: release
+          file: app/release/app-release.apk

--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -41,4 +41,4 @@ jobs:
           appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: release
-          file: app/release/app-release.apk
+          file: ./app/release/app-release.apk

--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew assembleRelease
 
       - name: Show ./app directory
-        run: ls -l ./app/build/outputs
+        run: ls -l ./app/build/outputs/apk
 
       - name: Deploy to App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1

--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew assembleRelease
 
       - name: Show ./app directory
-        run: ls -l ./app
+        run: ls -l ./app/build
 
       - name: Deploy to App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1

--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -47,4 +47,4 @@ jobs:
           appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: release
-          file: ./app/release/app-release.apk
+          file: ./app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # テストでdevelop指定
-          ref: 'develop'
+          # テストで本ブランチ指定
+          ref: 'feature/4-build-using-github-actions'
 
       - name: set up JDK 17
         uses: actions/setup-java@v2

--- a/.github/workflows/deploy-app-distribution.yml
+++ b/.github/workflows/deploy-app-distribution.yml
@@ -33,8 +33,8 @@ jobs:
           ENV_SIGN_STORE_PASSWORD: ${{secrets.ENV_SIGN_STORE_PASSWORD}}
         run: ./gradlew assembleRelease
 
-      - name: Find APK Location
-        run: find ./ -name app-release.apk
+      - name: Show ./app directory
+        run: ls -l ./app
 
       - name: Deploy to App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1

--- a/.github/workflows/deploy-releae-apk-to-app-distribution.yml
+++ b/.github/workflows/deploy-releae-apk-to-app-distribution.yml
@@ -1,19 +1,16 @@
 name: Deploy To App Distribution
 
-on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
+# FIXME: 完全自動化にはフローが未策定のため手動実行にしている
+# バージョンアップのPRがマージされたタイミングで自動実行したい
+on: [workflow_dispatch]
 
 jobs:
-  build:
+  deploy-release-apk:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
-          # テストで本ブランチ指定
-          ref: 'feature/4-build-using-github-actions'
+          ref: 'release'
 
       - name: set up JDK 17
         uses: actions/setup-java@v2
@@ -32,14 +29,11 @@ jobs:
 
       - name: Building Release APK
         env:
-          ENV_SIGN_KEYSTORE_BASE64: ${{secrets.ENV_SIGN_KEYSTORE_BASE64}}
-          ENV_SIGN_KEY_ALIAS: ${{secrets.ENV_SIGN_KEY_ALIAS}}
-          ENV_SIGN_KEY_PASSWORD: ${{secrets.ENV_SIGN_KEY_PASSWORD}}
-          ENV_SIGN_STORE_PASSWORD: ${{secrets.ENV_SIGN_STORE_PASSWORD}}
+          ENV_SIGN_KEYSTORE_BASE64: ${{ secrets.ENV_SIGN_KEYSTORE_BASE64 }}
+          ENV_SIGN_KEY_ALIAS: ${{ secrets.ENV_SIGN_KEY_ALIAS }}
+          ENV_SIGN_KEY_PASSWORD: ${{ secrets.ENV_SIGN_KEY_PASSWORD }}
+          ENV_SIGN_STORE_PASSWORD: ${{ secrets.ENV_SIGN_STORE_PASSWORD }}
         run: ./gradlew assembleRelease
-
-      - name: Show ./app directory
-        run: ls -l ./app/build/outputs/apk/release
 
       - name: Deploy to App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,7 +31,7 @@ android {
             val releaseKeystoreFileName = "release-keystore.jks"
             if (System.getenv("ENV_SIGN_KEYSTORE_BASE64") != null) {
                 System.getenv("ENV_SIGN_KEYSTORE_BASE64").let { base64 ->
-                    val decoder = Base64.getDecoder()
+                    val decoder = Base64.getMimeDecoder()
                     File(releaseKeystoreFileName).also { file ->
                         file.createNewFile()
                         file.writeBytes(decoder.decode(base64))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("com.google.dagger.hilt.android")
     id("kotlin-kapt")
+    id("com.google.gms.google-services")
 }
 
 android {
@@ -78,6 +79,8 @@ dependencies {
     implementation("com.google.dagger:hilt-android:$hiltVersion")
     implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
     kapt("com.google.dagger:hilt-compiler:$hiltVersion")
+    implementation(platform("com.google.firebase:firebase-bom:32.7.2"))
+    implementation("com.google.firebase:firebase-analytics")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     id("com.android.application") version "8.2.2" apply false
     id("org.jetbrains.kotlin.android") version "1.9.0" apply false
     id("com.google.dagger.hilt.android") version "2.48" apply false
+    id("com.google.gms.google-services") version "4.4.1" apply false
 }


### PR DESCRIPTION
## Overview
- Firebase App DistributionにRelease APKをアップロードするActionsワークフローの追加

## Implement Overview
- GitHub Secretsに各種秘匿情報を記載（PR対象外）
- App DistributionへのRelease APKアップロード用Actionsワークフローを実装
- app/build.gradle.ktsにRelease用署名の情報を追加

## Screen Shots
なし

## Related Issues
resolve #4 