### PR TITLE
feat: 🎸 modify arround `TaskListScreen` & `TaskDetailScreen`

### DIFF
--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/NavLinks.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/NavLinks.kt
@@ -16,4 +16,11 @@ sealed class NavLinks(val route: String) {
             return "taskDetail/${id}"
         }
     }
+    data object TaskCreate : NavLinks("taskCreate")
+    data object TaskEdit : NavLinks("taskEdit/{id}") {
+        const val ARGUMENT_ID = "id"
+        fun createRoute(id: Int): String {
+            return "taskEdit/${id}"
+        }
+    }
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/DummyModels.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/DummyModels.kt
@@ -12,7 +12,7 @@ import java.time.Instant
 
 // ダミーの課題ラッパー: デバッグ用
 fun makeDummyTaskSubjects(): List<TaskSubject> {
-    return (0..<20).map {
+    return (1..20).map {
         val taskSubject = TaskSubject()
         taskSubject.task = makeDummyTask(it)
         taskSubject.subTasks = makeDummySubTasks(taskId = it)
@@ -24,7 +24,7 @@ fun makeDummyTaskSubjects(): List<TaskSubject> {
 fun makeDummyTask(taskId: Int): Task {
     return Task(
         id = taskId,
-        title = "課題${taskId + 1}",
+        title = "課題${taskId}",
         colorValue = when (taskId % 3) {
             0 -> TaskColor.YELLOW.code
             1 -> TaskColor.RED.code
@@ -36,11 +36,11 @@ fun makeDummyTask(taskId: Int): Task {
 
 // ダミーの子課題リスト: デバッグ用
 fun makeDummySubTasks(taskId: Int = 0): List<SubTask> {
-    return (0..<10).map {
+    return (1..10).map {
         SubTask(
             id = it,
             taskId = taskId,
-            title = "課題${taskId + 1}の子課題${it + 1}",
+            title = "課題${taskId}の子課題${it}",
             status = when (taskId % 3) {
                 0 -> when (it) {
                     in 0..1 -> SubTaskStatus.COMPLETED

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/SubTask.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/SubTask.kt
@@ -1,6 +1,6 @@
 package com.dashimaki_dofu.mytaskmanagement.model
 
-import androidx.room.ColumnInfo
+import androidx.annotation.DrawableRes
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
@@ -31,19 +31,10 @@ data class SubTask(
     @ColumnInfo(index = true) var taskId: Int = defaultId,
     var title: String = "",
     var status: SubTaskStatus = SubTaskStatus.INCOMPLETE
-) {
-    val stampResourceId: Int?
-        get() {
-            return when (status) {
-                SubTaskStatus.INCOMPLETE -> R.drawable.mark_incomplete_checked
-                SubTaskStatus.COMPLETED -> R.drawable.mark_sumi_checked
-                else -> null
-            }
-        }
-}
+)
 
-enum class SubTaskStatus {
-    INCOMPLETE, // 未着手
-    ACTIVE,     // 着手中
-    COMPLETED,  // 完了
+enum class SubTaskStatus(@DrawableRes val stampResourceId: Int?, val text: String) {
+    INCOMPLETE(R.drawable.mark_incomplete_checked, "未着手"), // 未着手
+    ACTIVE(null, "着手中"),     // 着手中
+    COMPLETED(R.drawable.mark_sumi_checked, "完了");  // 完了
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/TaskSubject.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/TaskSubject.kt
@@ -1,7 +1,9 @@
 package com.dashimaki_dofu.mytaskmanagement.model
 
+import androidx.compose.ui.graphics.Color
 import androidx.room.Embedded
 import androidx.room.Relation
+import com.dashimaki_dofu.mytaskmanagement.ui.theme.TaskColor
 
 
 /**
@@ -31,5 +33,19 @@ class TaskSubject {
         get() {
             if (subTasks.isEmpty()) return 0f
             return subTasks.count { it.status == SubTaskStatus.COMPLETED } / subTasks.count().toFloat()
+        }
+
+    val progressRateString: String
+        get() {
+            return "${(progressRate * 100).toInt()}%"
+        }
+
+    val progressRateStringColor: Color
+        get() {
+            return if (subTasks.any { it.status != SubTaskStatus.COMPLETED } || subTasks.isEmpty()) {
+                TaskColor.LIGHT_GRAY.color
+            } else {
+                TaskColor.LIGHT_GREEN.color
+            }
         }
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
@@ -20,14 +20,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.constraintlayout.compose.ConstraintLayout
-import com.dashimaki_dofu.mytaskmanagement.R
 import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
 import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTaskSubjects
 
@@ -45,47 +43,59 @@ fun TaskListItem(taskSubject: TaskSubject, onClick: (id: Int) -> Unit) {
             .clickable {
                 onClick(taskSubject.task.id)
             }
-            .height(60.dp)
+            .height(64.dp)
             .shadow(
                 elevation = 6.dp,
                 shape = RoundedCornerShape(8.dp)
             )
             .background(
-                taskSubject.task.color.copy(alpha = 0.3f)
+                taskSubject.task.color
+                    .copy(alpha = 0.3f)
                     .compositeOver(Color.White)
             )
-        ,
-        contentAlignment = Alignment.Center,
     ) {
-        ConstraintLayout {
-            val (progressBarRef, progressTextRef) = createRefs()
-
-            Box(
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .background(taskSubject.task.color)
+                .fillMaxWidth(taskSubject.progressRate)
+        )
+        Box(
+            modifier = Modifier.padding(all = 8.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier
                     .fillMaxHeight()
-                    .background(taskSubject.task.color)
-                    .fillMaxWidth(taskSubject.progressRate)
-                    .constrainAs(progressBarRef) {}
-            )
-            Box(
-                modifier = Modifier.padding(all = 8.dp),
-                contentAlignment = Alignment.Center
+                    .fillMaxWidth()
             ) {
+                Spacer(modifier = Modifier.width(20.dp))
+                Text(
+                    text = taskSubject.task.title,
+                    modifier = Modifier
+                        .weight(1f),
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    fontSize = 16.sp,
+                    color = taskSubject.task.listTitleColor
+                )
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .fillMaxWidth()
+                    horizontalArrangement = Arrangement.End
                 ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Spacer(modifier = Modifier.width(40.dp))
-                        Text(
-                            text = taskSubject.task.title,
-                            fontSize = 24.sp,
-                            color = taskSubject.task.listTitleColor
-                        )
-                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        modifier = Modifier
+                            .width(68.dp),
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = taskSubject.progressRateStringColor,
+                        textAlign = TextAlign.End,
+                        text = taskSubject.progressRateString
+                    )
+                    Spacer(modifier = Modifier.width(16.dp))
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
@@ -104,16 +114,6 @@ fun TaskListItem(taskSubject: TaskSubject, onClick: (id: Int) -> Unit) {
                     }
                 }
             }
-            Text(
-                text = "${(taskSubject.progressRate * 100).toInt()}%",
-                fontSize = 12.sp,
-                fontWeight = FontWeight.Bold,
-                color = colorResource(id = R.color.lightGray1),
-                modifier = Modifier.constrainAs(progressTextRef) {
-                    bottom.linkTo(progressBarRef.bottom)
-                    centerAround(progressBarRef.absoluteRight)
-                }
-            )
         }
     }
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/MyTaskManagementApp.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/MyTaskManagementApp.kt
@@ -56,12 +56,18 @@ fun MyTaskManagementApp(mainViewModel: MainViewModel = viewModel()) {
                     }
                 )
             ) { backStackEntry ->
-                val viewModel = hiltViewModel<TaskDetailViewModel>()
+                val viewModel = hiltViewModel<TaskDetailViewModelImpl>()
                 val taskId = backStackEntry.arguments?.getInt(NavLinks.TaskDetail.ARGUMENT_ID) ?: -1
-                viewModel.setTaskId(taskId)
                 TaskDetailScreen(
-                    taskDetailViewModel = viewModel,
+                    taskId = taskId,
+                    viewModel = viewModel,
                     onClickNavigationIcon = {
+                        navController.navigateUp()
+                    },
+                    onClickEditButton = {
+                        navController.navigate(NavLinks.TaskEdit.createRoute(taskId))
+                    },
+                    onDeleteCompleted = {
                         navController.navigateUp()
                     }
                 )

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/MyTaskManagementApp.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/MyTaskManagementApp.kt
@@ -40,6 +40,9 @@ fun MyTaskManagementApp(mainViewModel: MainViewModel = viewModel()) {
                     taskListViewModel = viewModel,
                     onClickItem = { taskId ->
                         navController.navigate(NavLinks.TaskDetail.createRoute(taskId))
+                    },
+                    onClickAddTaskButton = {
+                        navController.navigate(NavLinks.TaskCreate.route)
                     }
                 )
             }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
@@ -18,6 +18,9 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -26,29 +29,30 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.constraintlayout.compose.ConstraintLayout
-import com.dashimaki_dofu.mytaskmanagement.R
+import com.dashimaki_dofu.mytaskmanagement.database.defaultId
 import com.dashimaki_dofu.mytaskmanagement.model.SubTask
-import com.dashimaki_dofu.mytaskmanagement.model.Task
-import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
 import com.dashimaki_dofu.mytaskmanagement.model.makeDummySubTasks
-import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTaskSubjects
 import com.dashimaki_dofu.mytaskmanagement.viewModel.TaskDetailViewModel
+import com.dashimaki_dofu.mytaskmanagement.viewModel.TaskDetailViewModelMock
 
 
 /**
@@ -57,22 +61,23 @@ import com.dashimaki_dofu.mytaskmanagement.viewModel.TaskDetailViewModel
  * Created by Yoshiyasu on 2024/02/10
  */
 
-@Composable
-fun TaskDetailScreen(
-    taskDetailViewModel: TaskDetailViewModel,
-    onClickNavigationIcon: () -> Unit
-) {
-    val taskSubject = taskDetailViewModel.taskSubject.collectAsState(makeEmptyTaskSubject())
-    
-    TaskDetailScreen(taskSubject = taskSubject.value, onClickNavigationIcon)
-}
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TaskDetailScreen(
-    taskSubject: TaskSubject,
-    onClickNavigationIcon: () -> Unit
+    taskId: Int,
+    viewModel: TaskDetailViewModel,
+    onClickNavigationIcon: () -> Unit,
+    onClickEditButton: () -> Unit,
+    onDeleteCompleted: () -> Unit
 ) {
+    val taskSubject = viewModel.taskSubject.collectAsState().value
+
+    val showDeleteAlertDialog = viewModel.showDeleteAlertDialogState.collectAsState().value
+
+    LaunchedEffect(Unit) {
+        viewModel.fetchTaskSubject(taskId)
+    }
+
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = MaterialTheme.colorScheme.background
@@ -81,7 +86,11 @@ fun TaskDetailScreen(
             topBar = {
                 TopAppBar(
                     title = {
-                        Text(taskSubject.task.title)
+                        Text(
+                            text = taskSubject.task.title,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
                     },
                     colors = TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -94,16 +103,41 @@ fun TaskDetailScreen(
                                 contentDescription = "go back"
                             )
                         }
+                    },
+                    actions = {
+                        IconButton(
+                            onClick = onClickEditButton
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Edit,
+                                contentDescription = "edit"
+                            )
+                        }
+                        IconButton(
+                            onClick = {
+                                viewModel.showDeleteAlertDialog()
+                            }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = "delete"
+                            )
+                        }
                     }
                 )
             }
         ) { innerPadding ->
-            if (taskSubject.task.id == emptyTaskId) {
-                CircularProgressIndicator()
-            } else {
-                Box(
-                    modifier = Modifier.padding(innerPadding)
-                ) {
+            Box(
+                modifier = Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize()
+            ) {
+                if (taskSubject.task.id == defaultId) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                    )
+                } else {
                     Box(
                         modifier = Modifier
                             .padding(all = 16.dp)
@@ -132,55 +166,81 @@ fun TaskDetailScreen(
                                 )
                             }
                             Spacer(modifier = Modifier.height(10.dp))
-                            ConstraintLayout(
-                                modifier = Modifier
-                                    .height(60.dp)
-                                    .border(
-                                        width = 4.dp,
-                                        color = taskSubject.task.color,
-                                        shape = RoundedCornerShape(12.dp)
-                                    )
-                                    .fillMaxWidth()
-                            ) {
-                                val (progressBarRef, progressTextRef) = createRefs()
 
+                            if (taskSubject.subTasks.isEmpty()) {
+                                Text(
+                                    modifier = Modifier
+                                        .fillMaxWidth(),
+                                    text = "子課題がありません\n右上の編集ボタンから子課題を登録しましょう",
+                                    textAlign = TextAlign.Center
+                                )
+                            } else {
                                 Box(
                                     modifier = Modifier
-                                        .fillMaxWidth(taskSubject.progressRate)
-                                        .fillMaxHeight()
+                                        .height(60.dp)
+                                        .clip(RoundedCornerShape(12.dp))
                                         .border(
-                                            width = 0.dp,
-                                            color = Color.White,
-                                            shape = RoundedCornerShape(
-                                                topStart = 12.dp,
-                                                bottomStart = 12.dp
-                                            )
-                                        )
-                                        .background(
+                                            width = 4.dp,
                                             color = taskSubject.task.color,
-                                            shape = RoundedCornerShape(
-                                                topStart = 12.dp,
-                                                bottomStart = 12.dp
-                                            )
+                                            shape = RoundedCornerShape(12.dp)
                                         )
-                                        .constrainAs(progressBarRef) {}
-                                )
-                                Text(
-                                    text = "${(taskSubject.progressRate * 100).toInt()}%",
-                                    fontSize = 20.sp,
-                                    fontWeight = FontWeight.Bold,
-                                    color = colorResource(id = R.color.lightGray1),
-                                    modifier = Modifier
-                                        .constrainAs(progressTextRef) {
-                                            bottom.linkTo(progressBarRef.bottom, margin = 2.dp)
-                                            centerAround(progressBarRef.absoluteRight)
+                                        .fillMaxWidth()
+                                ) {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth(taskSubject.progressRate)
+                                            .fillMaxHeight()
+                                            .background(color = taskSubject.task.color)
+                                    )
+                                    Text(
+                                        text = taskSubject.progressRateString,
+                                        fontSize = 32.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        color = taskSubject.progressRateStringColor,
+                                        modifier = Modifier
+                                            .align(Alignment.Center)
+                                    )
+                                }
+                                Spacer(modifier = Modifier.height(8.dp))
+                                LazyColumn {
+                                    items(taskSubject.subTasks) { subTask ->
+                                        SubTaskListItem(subTask = subTask)
+                                    }
+                                }
+
+                                if (showDeleteAlertDialog) {
+                                    AlertDialog(
+                                        onDismissRequest = {
+                                            viewModel.dismissDeleteAlertDialog()
+                                        },
+                                        confirmButton = {
+                                            TextButton(
+                                                onClick = {
+                                                    viewModel.deleteTask(
+                                                        taskSubject.task.id,
+                                                        completion = onDeleteCompleted
+                                                    )
+                                                }
+                                            ) {
+                                                Text(text = "OK")
+                                            }
+                                        },
+                                        dismissButton = {
+                                            TextButton(
+                                                onClick = {
+                                                    viewModel.dismissDeleteAlertDialog()
+                                                }
+                                            ) {
+                                                Text(text = "キャンセル")
+                                            }
+                                        },
+                                        title = {
+                                            Text(text = "${taskSubject.task.title}を削除します。よろしいですか？")
+                                        },
+                                        text = {
+                                            Text(text = "この操作は元に戻せません。")
                                         }
-                                )
-                            }
-                            Spacer(modifier = Modifier.height(8.dp))
-                            LazyColumn {
-                                items(taskSubject.subTasks) { subTask ->
-                                    SubTaskListItem(subTask = subTask)
+                                    )
                                 }
                             }
                         }
@@ -189,15 +249,6 @@ fun TaskDetailScreen(
             }
         }
     }
-}
-
-private const val emptyTaskId = -1
-
-fun makeEmptyTaskSubject(): TaskSubject {
-    val taskSubject = TaskSubject()
-    taskSubject.task = Task()
-    taskSubject.subTasks = emptyList()
-    return taskSubject
 }
 
 @Composable
@@ -223,7 +274,7 @@ fun SubTaskListItem(subTask: SubTask) {
                 .fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            when (val resourceId = subTask.stampResourceId) {
+            when (val resourceId = subTask.status.stampResourceId) {
                 null -> Text(text = "着手中")
                 else -> Image(
                     painter = painterResource(id = resourceId),
@@ -240,13 +291,16 @@ fun SubTaskListItem(subTask: SubTask) {
 @Composable
 fun TaskDetailScreenPreview() {
     TaskDetailScreen(
-        taskSubject = makeDummyTaskSubjects().first(),
-        onClickNavigationIcon = {}
+        taskId = 0,
+        viewModel = TaskDetailViewModelMock(),
+        onClickEditButton = {},
+        onClickNavigationIcon = {},
+        onDeleteCompleted = {}
     )
 }
 
 @Preview(showBackground = true)
 @Composable
 fun SubTaskListItemPreview() {
-    SubTaskListItem(subTask = makeDummySubTasks().first { it.id == 2 })
+    SubTaskListItem(subTask = makeDummySubTasks().first())
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskListScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskListScreen.kt
@@ -3,7 +3,11 @@ package com.dashimaki_dofu.mytaskmanagement.view.composable.screen
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -11,9 +15,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
 import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTaskSubjects
 import com.dashimaki_dofu.mytaskmanagement.view.composable.TaskList
@@ -29,13 +37,19 @@ import com.dashimaki_dofu.mytaskmanagement.viewModel.TaskListViewModel
 @Composable
 fun TaskListScreen(
     taskListViewModel: TaskListViewModel,
-    onClickItem: (id: Int) -> Unit
+    onClickItem: (id: Int) -> Unit,
+    onClickAddTaskButton: () -> Unit
 ) {
     val taskSubjects = taskListViewModel.taskSubjects.collectAsState(initial = emptyList())
 
+    LaunchedEffect(Unit) {
+        taskListViewModel.fetchTaskSubjects()
+    }
+
     TaskListScreen(
         taskSubjects = taskSubjects.value,
-        onClickItem = onClickItem
+        onClickItem = onClickItem,
+        onClickAddTaskButton = onClickAddTaskButton
     )
 }
 
@@ -43,7 +57,8 @@ fun TaskListScreen(
 @Composable
 fun TaskListScreen(
     taskSubjects: List<TaskSubject>,
-    onClickItem: (id: Int) -> Unit
+    onClickItem: (id: Int) -> Unit,
+    onClickAddTaskButton: () -> Unit
 ) {
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -58,15 +73,38 @@ fun TaskListScreen(
                     colors = TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.primaryContainer,
                         titleContentColor = MaterialTheme.colorScheme.primary
-                    )
+                    ),
+                    actions = {
+                        IconButton(
+                            onClick = onClickAddTaskButton
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Add,
+                                contentDescription = "go back"
+                            )
+                        }
+                    }
                 )
             }
         ) { innerPadding ->
-            Box(modifier = Modifier.padding(innerPadding)) {
-                TaskList(
-                    taskSubjects = taskSubjects,
-                    onClickItem = onClickItem
-                )
+            Box(
+                modifier = Modifier.padding(innerPadding)
+                    .fillMaxSize()
+            ) {
+                if (taskSubjects.isEmpty()) {
+                    Text(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(horizontal = 8.dp),
+                        textAlign = TextAlign.Center,
+                        text = "課題がありません。\n右上の+ボタンから課題を登録してください。"
+                    )
+                } else {
+                    TaskList(
+                        taskSubjects = taskSubjects,
+                        onClickItem = onClickItem
+                    )
+                }
             }
         }
     }
@@ -77,6 +115,7 @@ fun TaskListScreen(
 fun TaskListScreenPreview() {
     TaskListScreen(
         taskSubjects = makeDummyTaskSubjects(),
-        onClickItem = {}
+        onClickItem = {},
+        onClickAddTaskButton = {}
     )
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/viewModel/TaskDetailViewModel.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/viewModel/TaskDetailViewModel.kt
@@ -1,13 +1,15 @@
 package com.dashimaki_dofu.mytaskmanagement.viewModel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
+import com.dashimaki_dofu.mytaskmanagement.model.makeDummyTaskSubjects
 import com.dashimaki_dofu.mytaskmanagement.repository.TaskSubjectRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 
@@ -17,19 +19,50 @@ import javax.inject.Inject
  * Created by Yoshiyasu on 2024/02/13
  */
 
+abstract class TaskDetailViewModel : ViewModel() {
+    abstract val taskSubject: StateFlow<TaskSubject>
+    open val showDeleteAlertDialogState: StateFlow<Boolean> = MutableStateFlow(false)
+
+    open fun fetchTaskSubject(taskId: Int) = Unit
+    open fun showDeleteAlertDialog() = Unit
+    open fun dismissDeleteAlertDialog() = Unit
+    open fun deleteTask(taskId: Int, completion: () -> Unit) = Unit
+}
+
 @HiltViewModel
-class TaskDetailViewModel @Inject constructor(
+class TaskDetailViewModelImpl @Inject constructor(
     private val taskSubjectRepository: TaskSubjectRepository,
-) : ViewModel() {
-    private val taskId = MutableStateFlow(-1)
+) : TaskDetailViewModel() {
+    private val _taskSubject = MutableStateFlow(TaskSubject.initialize())
+    override val taskSubject = _taskSubject.asStateFlow()
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val taskSubject: Flow<TaskSubject> = taskId.flatMapLatest {
-        taskId -> taskSubjectRepository.getTaskSubject(taskId)
+    private val _showDeleteAlertDialogState = MutableStateFlow(false)
+    override val showDeleteAlertDialogState = _showDeleteAlertDialogState.asStateFlow()
+
+    override fun deleteTask(taskId: Int, completion: () -> Unit) {
+        viewModelScope.launch {
+            taskSubjectRepository.deleteTask(taskId)
+            completion.invoke()
+        }
     }
 
-    fun setTaskId(taskId: Int) {
-        this.taskId.value = taskId
+    override fun fetchTaskSubject(taskId: Int) {
+        viewModelScope.launch {
+            _taskSubject.value = taskSubjectRepository.getTaskSubject(taskId)
+        }
     }
+
+    override fun showDeleteAlertDialog() {
+        _showDeleteAlertDialogState.value = true
+    }
+
+    override fun dismissDeleteAlertDialog() {
+        _showDeleteAlertDialogState.value = false
+    }
+}
+
+class TaskDetailViewModelMock : TaskDetailViewModel() {
+    override val taskSubject: StateFlow<TaskSubject>
+        get() = MutableStateFlow(makeDummyTaskSubjects().first().also { it.subTasks = emptyList() })
 }
 

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/viewModel/TaskListViewModel.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/viewModel/TaskListViewModel.kt
@@ -1,8 +1,13 @@
 package com.dashimaki_dofu.mytaskmanagement.viewModel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.dashimaki_dofu.mytaskmanagement.model.TaskSubject
 import com.dashimaki_dofu.mytaskmanagement.repository.TaskSubjectRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 
@@ -16,5 +21,12 @@ import javax.inject.Inject
 class TaskListViewModel @Inject constructor(
     private val taskSubjectRepository: TaskSubjectRepository,
 ) : ViewModel() {
-    val taskSubjects = taskSubjectRepository.getAllTaskSubjects()
+    private val _taskSubjects = MutableStateFlow<List<TaskSubject>>(emptyList())
+    val taskSubjects = _taskSubjects.asStateFlow()
+
+    fun fetchTaskSubjects() {
+        viewModelScope.launch {
+            _taskSubjects.value = taskSubjectRepository.getAllTaskSubjects()
+        }
+    }
 }


### PR DESCRIPTION
## Overview
- 課題一覧 & 課題詳細画面の修正

## Implement Overview
- 各ダミーデータの id が 1 から始まるように修正
- `stampResourceId` を `SubTaskStatus` 側に移動
- `TaskSubject.progressRate` 関連の文字列プロパティを実装
- 課題一覧画面の修正
- 課題詳細画面の修正

## Screen Shots 
課題一覧画面 |
:--: |
<img height="600" alt="image" src="https://github.com/yoshiyasuko/MyTaskManagement/assets/21100316/bb1eebaf-82d9-45e8-b506-cb189face44c"> | 

課題詳細画面(子課題有) | 課題詳細画面(子課題無)
:--: | :--:
<img height="600" alt="image" src="https://github.com/yoshiyasuko/MyTaskManagement/assets/21100316/92fe9501-8c33-486c-9fb9-9f9fb60ede87"> | <img height="600" alt="image" src="https://github.com/yoshiyasuko/MyTaskManagement/assets/21100316/96efccc0-a15a-487e-9ba7-efd3862d7954">


## Related Issues
なし