### PR TITLE
fix: 🐛 cannot show delete alert if task has no subtask

### DIFF
--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
@@ -207,43 +207,42 @@ fun TaskDetailScreen(
                                         SubTaskListItem(subTask = subTask)
                                     }
                                 }
-
-                                if (showDeleteAlertDialog) {
-                                    AlertDialog(
-                                        onDismissRequest = {
-                                            viewModel.dismissDeleteAlertDialog()
-                                        },
-                                        confirmButton = {
-                                            TextButton(
-                                                onClick = {
-                                                    viewModel.deleteTask(
-                                                        taskSubject.task.id,
-                                                        completion = onDeleteCompleted
-                                                    )
-                                                }
-                                            ) {
-                                                Text(text = "OK")
-                                            }
-                                        },
-                                        dismissButton = {
-                                            TextButton(
-                                                onClick = {
-                                                    viewModel.dismissDeleteAlertDialog()
-                                                }
-                                            ) {
-                                                Text(text = "キャンセル")
-                                            }
-                                        },
-                                        title = {
-                                            Text(text = "${taskSubject.task.title}を削除します。よろしいですか？")
-                                        },
-                                        text = {
-                                            Text(text = "この操作は元に戻せません。")
-                                        }
-                                    )
-                                }
                             }
                         }
+                    }
+                    if (showDeleteAlertDialog) {
+                        AlertDialog(
+                            onDismissRequest = {
+                                viewModel.dismissDeleteAlertDialog()
+                            },
+                            confirmButton = {
+                                TextButton(
+                                    onClick = {
+                                        viewModel.deleteTask(
+                                            taskSubject.task.id,
+                                            completion = onDeleteCompleted
+                                        )
+                                    }
+                                ) {
+                                    Text(text = "OK")
+                                }
+                            },
+                            dismissButton = {
+                                TextButton(
+                                    onClick = {
+                                        viewModel.dismissDeleteAlertDialog()
+                                    }
+                                ) {
+                                    Text(text = "キャンセル")
+                                }
+                            },
+                            title = {
+                                Text(text = "${taskSubject.task.title}を削除します。よろしいですか？")
+                            },
+                            text = {
+                                Text(text = "この操作は元に戻せません。")
+                            }
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## Overview
- 課題が子課題を持っていない場合、課題詳細画面の削除ボタンを押しても削除ダイアログが出ず、課題が削除できない問題を修正

## Implement Overview
- `AlertDialog` 表示の記述が `if (taskSubject.subTasks.isEmpty())` の `else` ブロック内にあったため、ブロック外へ移動。

## Screen Shots
なし

## Related Issues
なし
