### PR TITLE
ci: 🎡 add workflow - bump minor version (only test)

### DIFF
--- a/.github/workflows/increment-minor-version.yml
+++ b/.github/workflows/increment-minor-version.yml
@@ -1,0 +1,41 @@
+name: Increment Minor Version
+
+on: [ workflow_dispatch ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant Permission gradlew
+        run: chmod +x gradlew
+
+      - name: Bump Minor Version
+        run: ./gradlew bumpMinorVersion
+
+      - name: Get Version
+        run: | 
+          echo "::set-output name=VERSION_CODE::$(./gradlew printVersionCode)"
+          echo "::set-output name=VERSION_NAME::$(./gradlew printVersionName)"
+        id: version
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update-app-minor-version-${{ steps.version.outputs.VERSION_NAME }}-${{ steps.version.outputs.VERSION_CODE }}
+          base: release
+          title: "chore: 🤖versionName: ${{ steps.version.outputs.VERSION_NAME }} / versionCode: ${{ steps.version.outputs.VERSION_CODE }}"
+          commit-message: "chore: 🤖versionName: ${{ steps.version.outputs.VERSION_NAME }} / versionCode: ${{ steps.version.outputs.VERSION_CODE }}"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -195,3 +195,15 @@ tasks.addRule("Pattern: bump<TYPE>Version") {
         }
     }
 }
+
+tasks.register("printVersionCode") {
+    doLast {
+        println(android.defaultConfig.versionCode)
+    }
+}
+
+tasks.register("printVersionName") {
+    doLast {
+        println(android.defaultConfig.versionName)
+    }
+}


### PR DESCRIPTION
## Overview
- マイナーバージョンをインクリメントしてコミット・PR作成を行うワークフローを追加
  - テストのため develop 実行

## Implement Overview
- Gradle Taskに以下を追加
  - `bump(Major/Minor/Patch)Version` : `versionCode` `versionName` をインクリメント
  - `printVersionCode` : `versionCode` を出力する
  - `printVersionName` : `versionName` を出力する
- マイナーバージョンとバージョンコードをインクリメントしてコミット・PR作成を行うワークフローを実装

## Screen Shots
なし

## Related Issues
なし