### PR TITLE
chore: 🤖 introduce `Crashlytics`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("com.google.dagger.hilt.android")
     id("kotlin-kapt")
     id("com.google.gms.google-services")
+    id("com.google.firebase.crashlytics")
 }
 
 android {
@@ -105,7 +106,8 @@ dependencies {
     implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
     kapt("com.google.dagger:hilt-compiler:$hiltVersion")
     implementation(platform("com.google.firebase:firebase-bom:32.7.2"))
-    implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.firebase:firebase-crashlytics-ktx:18.6.2")
+    implementation("com.google.firebase:firebase-analytics-ktx:21.5.1")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+        }
         release {
             isMinifyEnabled = false
             signingConfig = signingConfigs.getByName(releaseSigningConfigName)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    dependencies {
+        classpath("com.google.firebase:firebase-crashlytics-gradle:2.9.9")
+    }
+}
+
 plugins {
     id("com.android.application") version "8.2.2" apply false
     id("org.jetbrains.kotlin.android") version "1.9.0" apply false


### PR DESCRIPTION
## Overview
- Crashlyticsの導入

## Implement Overview
- Crashlyticsの導入
- Debug ビルドはアプリIDに `.debug` の Suffix をつける

## Screen Shots
### Debug ビルドでのクラッシュログ確認
<img width="1108" alt="image" src="https://github.com/yoshiyasuko/MyTaskManagement/assets/21100316/1fa132bd-2bef-4b9d-a919-66e9b035de2c">

## Related Issues
Resolve #51 
