### PR TITLE
feat: 🎸 modify timing of dismissing delete alert dialog

### DIFF
--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
@@ -218,6 +218,7 @@ fun TaskDetailScreen(
                             confirmButton = {
                                 TextButton(
                                     onClick = {
+                                        viewModel.dismissDeleteAlertDialog()
                                         viewModel.deleteTask(
                                             taskSubject.task.id,
                                             completion = onDeleteCompleted


### PR DESCRIPTION
## Overview
- 削除確認アラートで `OK` を押した時の、アラートが消えるタイミングを調整
  - Before: 削除完了後
  - After: `OK` 押下直後

## Implement Overview
- AlertDialogの `confirmButton` 押下時に `viewModel.dismissDeleteAlertDialog()` を呼ぶように

## Screen Shots
なし

## Related Issues
なし
