### PR TITLE
Revert "ci: 🎡 increment minor version if merge to release"

### DIFF
--- a/.github/workflows/increment-minor-version.yml
+++ b/.github/workflows/increment-minor-version.yml
@@ -1,10 +1,6 @@
 name: Increment Minor Version
 
-on:
-  workflow_dispatch:
-  push:
-    branches:
-      - release
+on: [ workflow_dispatch ]
 
 jobs:
   build:


### PR DESCRIPTION
## Overview
- Increment Minor Versionの実行タイミング修正をrevertする
  - これだとIncrement Minor Version のPRがマージされる度に Increment Minor Version が実行されてしまうため

## Implement Overview
なし

## Screen Shots
なし

## Related Issues
なし