### PR TITLE
fix: 🐛 crash of feedback screen

### DIFF
--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/activity/MainActivity.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/activity/MainActivity.kt
@@ -28,10 +28,15 @@ class MainActivity : ComponentActivity() {
         setContent {
             MyTaskManagementApp(
                 onClickSendFeedback = {
-                    Firebase.appDistribution.startFeedback(
-                        R.string.common_feedback_screenMessage,
-                        null
-                    )
+                    // FIXME: フィードバック送信機能。
+                    //  ここのデフォルトスクリーンショットはoffにしたい。
+                    //  第2引数のUriはスクリーンショットBitmapへのリンクを示していて、
+                    //  メソッドのドキュメントには「ここをnullにすればデフォルトスクリーンショットをoffにできるよ」
+                    //  と書いてあるが、nullにするとUri.getScheme()でNullPointerExceptionでクラッシュしてしまい機能しない。
+                    //  現状これを抑制する方法が思い付かないため、第2引数に何も渡さずデフォルトスクリーンショットをonにしている。
+                    Firebase
+                        .appDistribution
+                        .startFeedback(R.string.common_feedback_screenMessage)
                 }
             )
         }


### PR DESCRIPTION
## Overview
- フィードバック画面を開こうとするとクラッシュする問題を修正

## Implement Overview
- `Firebase.appDistribution.startFeedback(additionalFormText:, screenShot:)` の `screenshot` には何も渡さないようにする。
  - 渡さない理由はコードコメントを参照
  - これによりデフォルトスクリーンショットがONになる。（OFFにしたい）

## Screen Shots
なし

## Related Issues
#99 
