### PR TITLE
fix: 🐛 cancelling of copy alert dialog is deactivated

### DIFF
--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
@@ -342,7 +342,7 @@ fun TaskDetailScreen(
                                 dismissButton = {
                                     TextButton(
                                         onClick = {
-                                            viewModel.dismissDeleteAlertDialog()
+                                            viewModel.dismissCopyAlertDialog()
                                         }
                                     ) {
                                         Text(text = stringResource(id = R.string.common_cancel))


### PR DESCRIPTION
## Overview
- 課題コピーのダイアログで「キャンセル」を押してもダイアログが消えないのを修正

## Implement Overview

## Screen Shots

## Related Issues
#126 
