### PR TITLE
feat: 🎸 implement selecting task color

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <application
             android:name=".MyTaskManagementApplication"
-            android:allowBackup="true"
+            android:allowBackup="false"
             android:dataExtractionRules="@xml/data_extraction_rules"
             android:fullBackupContent="@xml/backup_rules"
             android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/Task.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/Task.kt
@@ -46,8 +46,8 @@ data class Task(
             return formattedDeadLineString + deadlineTimeString
         }
 
-    // 課題のベースカラー
-    val color: Color
+    // 課題の色をColorクラスで取得
+    val composableColor: Color
         get() {
             return Color(colorValue)
         }
@@ -56,7 +56,7 @@ data class Task(
     val listTitleColor: Color
         get() {
             // 明るさを暗くする
-            val argb = color.toArgb()
+            val argb = composableColor.toArgb()
             val hsl = FloatArray(3) { 0f }
             ColorUtils.RGBToHSL(
                 argb.red,

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/Task.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/Task.kt
@@ -52,6 +52,10 @@ data class Task(
             return Color(colorValue)
         }
 
+    // 課題の色をEnumで取得
+    val color: TaskColor
+        get() = TaskColor.of(colorValue)
+
     // 課題リスト上タイトルのフォントカラー
     val listTitleColor: Color
         get() {

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/TaskSubject.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/model/TaskSubject.kt
@@ -3,7 +3,6 @@ package com.dashimaki_dofu.mytaskmanagement.model
 import androidx.compose.ui.graphics.Color
 import androidx.room.Embedded
 import androidx.room.Relation
-import com.dashimaki_dofu.mytaskmanagement.ui.theme.TaskColor
 
 
 /**
@@ -49,9 +48,9 @@ class TaskSubject {
     val progressRateStringColor: Color
         get() {
             return if (subTasks.any { it.status != SubTaskStatus.COMPLETED } || subTasks.isEmpty()) {
-                TaskColor.LIGHT_GRAY.color
+                Color.Black
             } else {
-                TaskColor.LIGHT_GREEN.color
+                Color.Green
             }
         }
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/ui/theme/TaskColor.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/ui/theme/TaskColor.kt
@@ -13,7 +13,6 @@ enum class TaskColor(val code: Long) {
     YELLOW(0xfff8dc6c),
     RED(0xfff86e6c),
     BLUE(0xff6cbef8),
-    LIGHT_GRAY(0xff1c1d1d);
     LIGHT_GREEN(0xff149a48);
 
     companion object {

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/ui/theme/TaskColor.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/ui/theme/TaskColor.kt
@@ -13,8 +13,17 @@ enum class TaskColor(val code: Long) {
     YELLOW(0xfff8dc6c),
     RED(0xfff86e6c),
     BLUE(0xff6cbef8),
-    LIGHT_GREEN(0xff149a48),
     LIGHT_GRAY(0xff1c1d1d);
+    LIGHT_GREEN(0xff149a48);
+
+    companion object {
+        fun of(code: Long): TaskColor {
+            TaskColor.entries.forEach {
+                if (it.code == code) return it
+            }
+            return YELLOW
+        }
+    }
 
     val color: Color = Color(code)
 }

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/TaskListItem.kt
@@ -51,7 +51,7 @@ fun TaskListItem(taskSubject: TaskSubject, onClick: (id: Int) -> Unit) {
                 shape = RoundedCornerShape(8.dp)
             )
             .background(
-                taskSubject.task.color
+                taskSubject.task.composableColor
                     .copy(alpha = 0.3f)
                     .compositeOver(Color.White)
             )
@@ -60,7 +60,7 @@ fun TaskListItem(taskSubject: TaskSubject, onClick: (id: Int) -> Unit) {
         Box(
             modifier = Modifier
                 .fillMaxHeight()
-                .background(taskSubject.task.color)
+                .background(taskSubject.task.composableColor)
                 .fillMaxWidth(taskSubject.progressRate)
         )
         //endregion

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskDetailScreen.kt
@@ -202,7 +202,7 @@ fun TaskDetailScreen(
                                     shape = RoundedCornerShape(8.dp)
                                 )
                                 .background(
-                                    taskSubject.task.color
+                                    taskSubject.task.composableColor
                                         .copy(alpha = 0.3f)
                                         .compositeOver(Color.White)
                                 )
@@ -238,7 +238,7 @@ fun TaskDetailScreen(
                                             .clip(RoundedCornerShape(12.dp))
                                             .border(
                                                 width = 4.dp,
-                                                color = taskSubject.task.color,
+                                                color = taskSubject.task.composableColor,
                                                 shape = RoundedCornerShape(12.dp)
                                             )
                                             .fillMaxWidth()
@@ -247,7 +247,7 @@ fun TaskDetailScreen(
                                             modifier = Modifier
                                                 .fillMaxWidth(taskSubject.progressRate)
                                                 .fillMaxHeight()
-                                                .background(color = taskSubject.task.color)
+                                                .background(color = taskSubject.task.composableColor)
                                         )
                                         Text(
                                             text = taskSubject.progressRateString,

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskEditScreen.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskEditScreen.kt
@@ -1,6 +1,8 @@
 package com.dashimaki_dofu.mytaskmanagement.view.composable.screen
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -48,6 +50,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -83,6 +86,7 @@ fun TaskEditScreen(
     val showDatePicker = viewModel.showDatePickerState.collectAsState().value
     val showTimePicker = viewModel.showTimePickerState.collectAsState().value
     val showSaveErrorDialog = viewModel.showAlertDialogState.collectAsState().value
+    val showSelectTaskColorDialog = viewModel.showSelectTaskColorDialogState.collectAsState().value
 
     val datePickerState = rememberDatePickerState(
         initialSelectedDateMillis = Instant.now()
@@ -132,6 +136,15 @@ fun TaskEditScreen(
                         }
                     },
                     actions = {
+                        Box(
+                            modifier = Modifier
+                                .size(24.dp)
+                                .background(task.taskColor.color)
+                                .border(width = 1.dp, color = Color.Black)
+                                .clickable {
+                                    viewModel.showSelectTaskColorDialog()
+                                }
+                        )
                         TextButton(
                             onClick = {
                                 if (!task.isTitleValid ||
@@ -363,6 +376,21 @@ fun TaskEditScreen(
                                     }
                                 },
                                 dismissButton = null
+                            )
+                        }
+                        //endregion
+
+                        //region TaskSelectColorDialog
+                        if (showSelectTaskColorDialog) {
+                            TaskSelectColorDialog(
+                                onDismiss = {
+                                    viewModel.dismissSelectTaskColorDialog()
+                                },
+                                currentTaskColor = task.taskColor,
+                                onItemClick = {
+                                    viewModel.dismissSelectTaskColorDialog()
+                                    viewModel.updateTaskColor(it)
+                                }
                             )
                         }
                         //endregion

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskSelectColorDialog.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/view/composable/screen/TaskSelectColorDialog.kt
@@ -1,0 +1,126 @@
+package com.dashimaki_dofu.mytaskmanagement.view.composable.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import com.dashimaki_dofu.mytaskmanagement.R
+import com.dashimaki_dofu.mytaskmanagement.ui.theme.TaskColor
+
+
+/**
+ * TaskSelectColorScreen
+ *
+ * Created by Yoshiyasu on 2024/06/08
+ */
+
+@Composable
+fun TaskSelectColorDialog(
+    onDismiss: () -> Unit,
+    currentTaskColor: TaskColor,
+    onItemClick: (TaskColor) -> Unit,
+) {
+    val dialogWidth = 300.dp
+    val itemSpace = 8.dp
+    var selectedTaskColorState by remember { mutableStateOf(currentTaskColor) }
+
+    AlertDialog(
+        modifier = Modifier
+            .width(dialogWidth),
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false
+        ),
+        onDismissRequest = onDismiss,
+        text = {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(itemSpace)
+            ) {
+                item {
+                    Text(text = stringResource(id = R.string.taskEdit_selectColorDialog_title))
+                }
+
+                items(
+                    items = TaskColor.entries.chunked(3)
+                ) { taskColorListOfRow ->
+                    TaskSelectColorGridRow(
+                        itemSpace = itemSpace,
+                        dialogWidth = dialogWidth,
+                        taskColorListOfRow = taskColorListOfRow,
+                        selectedTaskColor = selectedTaskColorState,
+                        onItemClick = {
+                            selectedTaskColorState = it
+                            onItemClick.invoke(it)
+                        }
+                    )
+                }
+            }
+        },
+        confirmButton = {},
+    )
+}
+
+@Composable
+fun TaskSelectColorGridRow(
+    itemSpace: Dp,
+    dialogWidth: Dp,
+    taskColorListOfRow: List<TaskColor>,
+    selectedTaskColor: TaskColor,
+    onItemClick: (TaskColor) -> Unit
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(itemSpace)
+    ) {
+        taskColorListOfRow.forEach {
+            TaskSelectColorItem(
+                isSelected = selectedTaskColor == it,
+                // FIXME: dialogのpaddingを取得する方法が微妙なため、一旦固定値で計算。
+                itemSize = ((dialogWidth.value - 2 * 16 - 2 * itemSpace.value - 20) / 3).dp,
+                taskColor = it,
+                onItemClick = onItemClick
+            )
+        }
+    }
+}
+
+@Composable
+fun TaskSelectColorItem(
+    isSelected: Boolean,
+    itemSize: Dp,
+    taskColor: TaskColor,
+    onItemClick: (TaskColor) -> Unit
+) {
+    BoxWithConstraints {
+        Box(
+            modifier = Modifier
+                .size(itemSize)
+                .background(color = taskColor.color)
+                .border(
+                    width = if (isSelected) 4.dp else 0.dp,
+                    color = Color.Black
+                )
+                .clickable {
+                    onItemClick.invoke(taskColor)
+                }
+        )
+    }
+}

--- a/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/viewModel/TaskEditViewModel.kt
+++ b/app/src/main/java/com/dashimaki_dofu/mytaskmanagement/viewModel/TaskEditViewModel.kt
@@ -9,6 +9,7 @@ import com.dashimaki_dofu.mytaskmanagement.model.SubTask
 import com.dashimaki_dofu.mytaskmanagement.model.SubTaskStatus
 import com.dashimaki_dofu.mytaskmanagement.model.Task
 import com.dashimaki_dofu.mytaskmanagement.repository.TaskSubjectRepository
+import com.dashimaki_dofu.mytaskmanagement.ui.theme.TaskColor
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -36,6 +37,7 @@ abstract class TaskEditViewModel : ViewModel() {
         data class TaskState(
             var id: Int = defaultId,
             var title: String = "",
+            var taskColor: TaskColor = TaskColor.YELLOW,
             var deadlineDate: Instant? = null,
             var deadlineTime: LocalTime? = null,
             var isTitleValid: Boolean = false,
@@ -44,6 +46,7 @@ abstract class TaskEditViewModel : ViewModel() {
             constructor(task: Task) : this() {
                 id = task.id
                 title = task.title
+                taskColor = task.color
                 deadlineDate = task.deadlineDate
                 deadlineTime = task.deadlineTime
                 isTitleValid = task.title.isNotEmpty()
@@ -97,11 +100,13 @@ abstract class TaskEditViewModel : ViewModel() {
     open val showDatePickerState: StateFlow<Boolean> = MutableStateFlow(false)
     open val showTimePickerState: StateFlow<Boolean> = MutableStateFlow(false)
     open val showAlertDialogState: StateFlow<Boolean> = MutableStateFlow(false)
+    open val showSelectTaskColorDialogState: StateFlow<Boolean> = MutableStateFlow(false)
     //endregion
 
     //region functions
     open fun loadTaskSubject(taskId: Int?) = Unit
     open fun updateTaskTitle(title: String) = Unit
+    open fun updateTaskColor(taskColor: TaskColor) = Unit
     open fun updateTaskDeadline(dateMillis: Long?) = Unit
     open fun updateTaskDeadlineTime(hour: Int, minute: Int) = Unit
     open fun clearTaskDeadlineTime() = Unit
@@ -117,6 +122,8 @@ abstract class TaskEditViewModel : ViewModel() {
     open fun dismissTimePicker() = Unit
     open fun showAlertDialog() = Unit
     open fun dismissAlertDialog() = Unit
+    open fun showSelectTaskColorDialog() = Unit
+    open fun dismissSelectTaskColorDialog() = Unit
     //endregion
 }
 //endregion
@@ -142,6 +149,9 @@ class TaskEditViewModelImpl @Inject constructor(
 
     private val _showAlertDialogState = MutableStateFlow(false)
     override val showAlertDialogState = _showAlertDialogState.asStateFlow()
+
+    private val _showSelectTaskColorDialogState = MutableStateFlow(false)
+    override val showSelectTaskColorDialogState = _showSelectTaskColorDialogState.asStateFlow()
     //endregion
 
     //region methods
@@ -163,6 +173,14 @@ class TaskEditViewModelImpl @Inject constructor(
             it.copy(
                 title = title,
                 isTitleValid = title.isNotEmpty()
+            )
+        }
+    }
+
+    override fun updateTaskColor(taskColor: TaskColor) {
+        _taskState.update {
+            it.copy(
+                taskColor = taskColor
             )
         }
     }
@@ -201,6 +219,7 @@ class TaskEditViewModelImpl @Inject constructor(
             val task = Task()
             task.id = _taskState.value.id
             task.title = _taskState.value.title
+            task.colorValue = _taskState.value.taskColor.code
             task.deadlineDate = _taskState.value.deadlineDate
             task.deadlineTime = _taskState.value.deadlineTime
 
@@ -273,6 +292,10 @@ class TaskEditViewModelImpl @Inject constructor(
         _showAlertDialogState.value = true
     }
 
+    override fun showSelectTaskColorDialog() {
+        _showSelectTaskColorDialogState.value = true
+    }
+
     override fun dismissDatePicker() {
         _showDatePickerState.value = false
     }
@@ -283,6 +306,10 @@ class TaskEditViewModelImpl @Inject constructor(
 
     override fun dismissAlertDialog() {
         _showAlertDialogState.value = false
+    }
+
+    override fun dismissSelectTaskColorDialog() {
+        _showSelectTaskColorDialogState.value = false
     }
     //endregion
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,4 +38,5 @@
     <string name="taskEdit.saveTaskErrorDialog.taskDeadlineDateNotValid">締切日を入力してください</string>
     <string name="taskEdit.saveTaskErrorDialog.subTaskTitleNotValid">子課題%dのタイトルが入力されていません</string>
     <string name="taskEdit.subTask.title">子課題%d</string>
+    <string name="taskEdit.selectColorDialog.title">課題の背景色を選択してください</string>
 </resources>


### PR DESCRIPTION
## Overview
- 課題の背景色選択を実装

## Implement Overview
- 課題の背景色選択用のダイアログ `TaskSelectColorDialog` を実装
- 課題編集画面のAppBarに背景色選択 & 現在の背景色を反映するボタンを追加
- 背景色を選択して `保存` をタップで、選択した背景色が反映されるように。

## Screen Shots

https://github.com/yoshiyasuko/MyTaskManagement/assets/21100316/dab7dbf9-2ebf-44dd-8fe3-c5276c17faa6

## Related Issues
Resolve #127 
